### PR TITLE
feat(gen-cpp): add continuous batching contracts

### DIFF
--- a/metainfer/tasks/gen_cpp_infer_framework/notebooks/02_qwen3_forwrad compute.md
+++ b/metainfer/tasks/gen_cpp_infer_framework/notebooks/02_qwen3_forwrad compute.md
@@ -95,6 +95,8 @@ Global tensors:
 | lm head | `output.weight` | `{n_embd, n_vocab}` | optional, can tie to token embedding |
 | rerank/classifier head | `cls.output.weight` | `{n_embd, n_cls_out}` | optional |
 
+上表的 `output.weight optional` 是通用 llama.cpp 架构兼容行为，不是当前固定模型的 Loader 契约。当前 Qwen3-8B 的 `tie_word_embeddings=false`，所以 `05_qwen3_gguf_loader_notes.md` 必须要求独立 `output.weight`；缺失时不能回退到 token embedding。
+
 Per-layer tensors, for layer `i`:
 
 | Tensor | Name in GGUF | Shape in llama.cpp allocation | Required |

--- a/metainfer/tasks/gen_cpp_infer_framework/notebooks/03_qwen3_8b_contract.md
+++ b/metainfer/tasks/gen_cpp_infer_framework/notebooks/03_qwen3_8b_contract.md
@@ -9,7 +9,7 @@
 目标是 **Qwen3-8B Dense、单请求（B=1）、单卡** 的自回归生成：
 
 ```text
-HF config.json + safetensors
+Qwen3-8B Q8_0 GGUF
         ↓
 ModelConfig / WeightLoader
         ↓
@@ -22,11 +22,13 @@ KVCache + BackendOps (GEMM / RMSNorm / RoPE / GQA)
 
 第一版不需要实现 TP、连续批处理、paged allocator、CUDA Graph、LoRA、MoE、speculative decoding 或服务调度。它们是吞吐优化/框架能力；先让单序列的 logits 与参考实现一致。
 
+> **多并发实现覆盖说明：** 本文后续关于单请求 `B=1`、单一 `KVCache::length` 和单行 logits 的描述仅适用于首版 bring-up。要实现多个 HTTP 请求的 continuous batching，必须先阅读并遵守 `09_continuous_batching_contract.md`；其中的 `slot_id`、`RuntimeBatch` 和 `[layer][slot][position][head][dim]` KV 所有权契约覆盖本文的单序列生命周期描述。
+
 虽然来源契约的运行范围是 `B=1, TP=4`，这里的主设计故意采用单卡全量权重。这样没有 all-reduce，也更容易验证数学与权重布局；TP=4 的扩展规则见第 9 节。
 
-## 2. 配置：运行时读取，8B 数字只作校验
+## 2. 配置：固定 Qwen3-8B，GGUF metadata 用于校验
 
-不要把下表硬编码为唯一真相。加载 `config.json`，并校验模型与这些 Qwen3-8B 参考值一致；若没有 `head_dim`，使用 `hidden_size / num_attention_heads`。
+当前小框架不做通用模型注册，只支持固定 Qwen3-8B。下表是 runtime 真值；Loader 读取 GGUF metadata 后逐项校验，任何关键字段不一致都应报错，而不是动态切换到其他尺寸。
 
 | 字段 | Qwen3-8B 参考值 | C++ 用途 |
 | --- | ---: | --- |
@@ -75,12 +77,15 @@ struct ModelConfig {
 
 struct LayerWeights {
     Tensor attn_norm;         // [H]
-    Tensor qkv;               // [Q + K + V, H] = [6144, 4096]
+    Tensor q_proj;            // [Q, H] = [4096, 4096]
+    Tensor k_proj;            // [K, H] = [1024, 4096]
+    Tensor v_proj;            // [Vkv, H] = [1024, 4096]
     Tensor q_norm;            // [D] = [128]
     Tensor k_norm;            // [D] = [128]
     Tensor o_proj;            // [H, H]
     Tensor ffn_norm;          // [H]
-    Tensor gate_up;           // [2I, H] = [24576, 4096]
+    Tensor gate_proj;         // [I, H] = [12288, 4096]
+    Tensor up_proj;           // [I, H] = [12288, 4096]
     Tensor down_proj;         // [H, I] = [4096, 12288]
 };
 
@@ -98,28 +103,28 @@ struct KVCache {
 
 `KVCache::length` 是一个请求的逻辑长度，而不是每层各自维护的计数器。每一层必须在同一个 position 写入 K/V；否则层间会读取不同 token 历史，结果会静默错误。
 
-## 4. 权重加载与融合布局
+## 4. 权重加载布局与可选融合
 
-HF checkpoint 是分离投影，而运行时可将它们融合为较少的 GEMM。这个融合只改变存储/调度，不能改变行段顺序。
+GGUF 为当前目标提供独立 Q/K/V 和 gate/up tensor。首版保持独立，直接匹配现有 compact kernel 接口；后续可以融合为较少的 GEMM，但融合只改变存储/调度，不能改变行段顺序，而且必须补齐 `04_qwen3_z200_operator_contract.md` 第 6 节的布局 helper。
 
 | HF key | HF shape（8B） | C++ 目标 | 操作 |
 | --- | --- | --- | --- |
 | `model.embed_tokens.weight` | `[V, H]` | `embed_tokens` | 直接复制 |
-| `layers.i.self_attn.q_proj.weight` | `[4096, 4096]` | `qkv[0:4096, :]` | 放在 Q 段 |
-| `layers.i.self_attn.k_proj.weight` | `[1024, 4096]` | `qkv[4096:5120, :]` | 紧跟 Q 的 K 段 |
-| `layers.i.self_attn.v_proj.weight` | `[1024, 4096]` | `qkv[5120:6144, :]` | 最后的 V 段 |
+| `layers.i.self_attn.q_proj.weight` | `[4096, 4096]` | `q_proj` | 首版独立保存 |
+| `layers.i.self_attn.k_proj.weight` | `[1024, 4096]` | `k_proj` | 首版独立保存 |
+| `layers.i.self_attn.v_proj.weight` | `[1024, 4096]` | `v_proj` | 首版独立保存 |
 | `layers.i.self_attn.o_proj.weight` | `[4096, 4096]` | `o_proj` | 直接复制 |
 | `layers.i.self_attn.q_norm.weight` | `[128]` | `q_norm` | 直接复制 |
 | `layers.i.self_attn.k_norm.weight` | `[128]` | `k_norm` | 直接复制 |
 | `layers.i.input_layernorm.weight` | `[4096]` | `attn_norm` | 直接复制 |
 | `layers.i.post_attention_layernorm.weight` | `[4096]` | `ffn_norm` | 直接复制 |
-| `layers.i.mlp.gate_proj.weight` | `[12288, 4096]` | `gate_up[0:12288, :]` | gate 在前 |
-| `layers.i.mlp.up_proj.weight` | `[12288, 4096]` | `gate_up[12288:24576, :]` | up 在后 |
+| `layers.i.mlp.gate_proj.weight` | `[12288, 4096]` | `gate_proj` | 首版独立保存 |
+| `layers.i.mlp.up_proj.weight` | `[12288, 4096]` | `up_proj` | 首版独立保存 |
 | `layers.i.mlp.down_proj.weight` | `[4096, 12288]` | `down_proj` | 直接复制 |
 | `model.norm.weight` | `[4096]` | `final_norm` | 直接复制 |
 | `lm_head.weight` | `[V, H]` | `lm_head` | 直接复制；仅配置要求时复用 embedding |
 
-两条不可交换的顺序：
+若后续启用融合，两条不可交换的顺序是：
 
 ```text
 qkv     = concat(Q, K, V, dim=0)       // 不是 Q-V-K
@@ -136,7 +141,9 @@ gate_up = concat(gate, up, dim=0)      // 不是 up-gate
 residual = x
 h        = RMSNorm(x, attn_norm)
 
-[q, k, v] = split(linear(h, qkv), [4096, 1024, 1024])
+q = linear(h, q_proj)
+k = linear(h, k_proj)
+v = linear(h, v_proj)
 q = reshape(q, [T, 32, 128])
 k = reshape(k, [T,  8, 128])
 v = reshape(v, [T,  8, 128])
@@ -152,7 +159,8 @@ x = residual + linear(reshape(a, [T, H]), o_proj)
 
 residual = x
 h        = RMSNorm(x, ffn_norm)
-[gate, up] = split(linear(h, gate_up), [I, I])
+gate = linear(h, gate_proj)
+up   = linear(h, up_proj)
 x = residual + linear(silu(gate) * up, down_proj)
 ```
 
@@ -249,7 +257,7 @@ struct BlockQ8_0 {
 w[i] = fp16_to_fp32(block.d) * fp32(block.qs[i % 32]);
 ```
 
-加载器必须校验 `sizeof(BlockQ8_0) == 34`、被量化矩阵的 `K % 32 == 0`、shape 与 GGUF 元数据一致。QKV 和 gate-up 可通过按输出行拼接已经量化的完整行来融合；不能切开或重排一行内部的 Q8_0 block。
+加载器必须校验 `sizeof(BlockQ8_0) == 34`、被量化矩阵的 `K % 32 == 0`、shape 与 GGUF 元数据一致。首版保持独立 Q/K/V 和 gate/up。若后续融合，只能按输出行拼接已经量化的完整行，不能切开或重排一行内部的 Q8_0 block。
 
 标准 hipBLAS 的 INT8 GEMM 不能直接表达“FP32/FP16 激活 × GGUF Q8_0 权重”：Q8_0 的 scale 沿 K 维每 32 个元素变化。因此首版不要把 `BlockQ8_0*` 直接传给普通 INT8 GEMM。当前正确路径是：
 
@@ -271,8 +279,8 @@ Y[M, N] = X[M, K] @ W[N, K]^T
 
 Agent 生成 runtime 时应在模型初始化阶段完成以下工作，禁止在逐层 forward 中反复 `hipMalloc/hipFree`：
 
-1. 读取配置并执行第 2 节的 shape 校验。
-2. 加载 GGUF Q8_0 tensor；按第 4 节映射或融合 QKV、gate-up，Q8_0 权重常驻 device memory。
+1. 构造固定 Qwen3-8B config，并用 GGUF metadata 执行第 2 节的 shape 校验。
+2. 加载 GGUF Q8_0 tensor；按第 4 节首版独立映射 Q/K/V 和 gate/up，Q8_0 权重常驻 device memory。
 3. 创建一个 hipBLAS handle，并让所有 kernel、cast、dequant、GEMM 使用同一条 HIP stream，依靠流内顺序保证依赖。
 4. 分配可复用的 FP32 激活区、attention/MLP 中间区、logits、KV cache。
 5. 分配一个 FP16 激活 workspace，容量至少为本次最大 GEMM 的 `M * K` 个元素。prefill 太长时应先按 token chunk 限制 `M`，而不是无上限扩大 workspace。
@@ -286,13 +294,13 @@ Qwen3-8B 最大的 FP16 临时权重是 LM Head：
 = 1187 MiB ≈ 1.159 GiB
 ```
 
-作为对比，gate-up 的临时权重为：
+作为对比，首版单个 gate 或 up 的临时权重为：
 
 ```text
-24576 * 4096 * 2 bytes = 192 MiB
+12288 * 4096 * 2 bytes = 96 MiB
 ```
 
-因此只按 gate-up 分配 192 MiB 会在 LM Head 处失败。首版最简单的策略是分配约 1.159 GiB 的单个权重 workspace，让所有线性层复用；若 `hipMemGetInfo` 显示余量不足，再实现第 8.5 节的 LM Head 分块。
+即使后续 fused gate-up 也只有 192 MiB，仍会在 LM Head 处失败。首版最简单的策略是分配约 1.159 GiB 的单个权重 workspace，让所有线性层复用；若 `hipMemGetInfo` 显示余量不足，再实现第 8.5 节的 LM Head 分块。
 
 当前 FP32 KV cache 在 `max_seq_len=4096` 时为：
 
@@ -320,9 +328,12 @@ for layer = 0 .. 35:
   residual = x_fp32
   h = RMSNorm(x_fp32, attn_norm)          // FP32
 
-  qkv = q8_linear(h, qkv_weight,
-                  M=T, N=6144, K=4096)    // 输出 FP32
-  split/pack -> q[T,32,128], k/v[T,8,128] // T>1 时必须搬成 compact，不能只偏移指针
+  q = q8_linear(h, q_weight,
+                M=T, N=4096, K=4096)      // compact FP32 [T,4096]
+  k = q8_linear(h, k_weight,
+                M=T, N=1024, K=4096)      // compact FP32 [T,1024]
+  v = q8_linear(h, v_weight,
+                M=T, N=1024, K=4096)      // compact FP32 [T,1024]
   per_head_rms(q, q_norm)
   per_head_rms(k, k_norm)
   RoPE(q, absolute_positions)
@@ -336,9 +347,11 @@ for layer = 0 .. 35:
 
   residual = x_fp32
   h = RMSNorm(x_fp32, ffn_norm)
-  gate_up = q8_linear(h, gate_up_weight,
-                      M=T, N=24576, K=4096)
-  ffn = strided_SwiGLU(gate_up)            // 或先 pack gate/up 再调用现有 SwiGLU
+  gate = q8_linear(h, gate_weight,
+                   M=T, N=12288, K=4096)
+  up = q8_linear(h, up_weight,
+                 M=T, N=12288, K=4096)
+  ffn = SwiGLU(gate, up)
   down = q8_linear(ffn, down_proj,
                    M=T, N=4096, K=12288)
   x_fp32 = residual + down
@@ -350,7 +363,7 @@ logits[1,V] = q8_linear(last_hidden, lm_head,
 
 关键点是 LM Head 的 `M=1`：prefill 生成只需要最后一个 prompt token 的 logits。绝不能为了取最后一行而计算 `[T, 151936]` 的完整 logits。若将 prompt 分块，还必须确保 attention 保持全局 causal 语义，且最终仅在最后一个 chunk 的最后一个位置执行 LM Head。
 
-这里的 QKV split/pack 和 strided SwiGLU 是 `T>1` prefill 的正确性要求，当前参考源码尚未提供这两个 helper；原因和两种补齐方式见 `04_qwen3_z200_operator_contract.md` 第 6 节。
+首版独立投影直接得到 compact tensor，不需要 QKV split/pack 或 strided SwiGLU。若后续启用 fused QKV/gate-up 优化，这两个 helper 就会成为 `T>1` prefill 的正确性前置条件，详见 `04_qwen3_z200_operator_contract.md` 第 6 节。
 
 ### 8.4 单卡 decode 参考调用流程
 
@@ -361,21 +374,21 @@ token_id -> Q8_0 embedding row -> x_fp32[1,H]
 
 for each layer:
   attn norm
-  q8 qkv linear (M=1)
+  q8 q/k/v independent linears (M=1)
   q/k per-head norm -> RoPE(position=cache.length)
   write K/V at cache.length
   decode GQA over [0, cache.length]
   q8 o linear (M=1) -> residual add
   ffn norm
-  q8 gate-up linear (M=1) -> SwiGLU
+  q8 gate/up independent linears (M=1) -> SwiGLU
   q8 down linear (M=1) -> residual add
 
 final norm
 q8 lm_head linear (M=1) -> logits[V]
-sample -> cache.length += 1
+forward success -> cache.length += 1
 ```
 
-在此正确性版本中，每层的 QKV、O、gate-up、down，以及最终 LM Head 都会在各自调用前解量化一次。不要把“每个算子都解量化”理解成要单独保存 36 层的 FP16 副本；它们按流串行地覆盖同一个权重 workspace。
+在此正确性版本中，每层的 Q/K/V、O、gate、up、down，以及最终 LM Head 都会在各自调用前解量化一次。不要把“每个算子都解量化”理解成要单独保存 36 层的 FP16 副本；它们按流串行地覆盖同一个权重 workspace。
 
 为了先跑通，允许这种重复解量化；为了提高 decode 速度，后续应优先实现直接读取 Q8_0 的 fused GEMV/GEMM（decode 的 `M=1` 特别适合 GEMV），而不是长期依赖“整矩阵解到 FP16 + hipBLAS”。
 
@@ -424,10 +437,10 @@ decode(token_1) → logits      → sample(token_2)
 
 验收按下面顺序做，能最快定位错误：
 
-1. 加载检查：36 层的每个 key 都存在，融合后的 QKV/gate-up shape 正确。
+1. 加载检查：36 层的每个独立 Q/K/V、gate/up key 都存在且 shape 正确；`output.weight` 必须独立存在。
 2. 固定小 prompt，比较 embedding、第一层 Q/K/V、第一层 attention 输出、第一层 MLP 输出、最终最后一行 logits；逐级比较比只比较最终 token 更容易发现布局错误。
 3. 对同一 token 序列，比较「一次性 full prefill 的最后 logits」与「前 `S-1` token prefill + 第 `S` token decode」的最后 logits。两者应在所选 dtype 的允许误差内一致。
-4. 固定 greedy sampling，比较连续生成的 token id；不一致时优先检查 QKV 拼接、gate/up 顺序、Q/K norm、RoPE position、KV 写入索引和残差加法。
+4. 固定 greedy sampling，比较连续生成的 token id；不一致时优先检查 Q/K/V layout、gate/up 配对、Q/K norm、RoPE position、KV 写入索引和残差加法。
 5. 只在正确性通过后，才融合 RMSNorm+residual、QKV GEMM、RoPE、paged attention 或加入 CUDA Graph。
 
 ## 10. 后续 TP=4 扩展（不是第一版前置条件）
@@ -445,9 +458,9 @@ TP 下要保证每个 rank 的 K/V cache 只存自己的两个 KV heads；不要
 
 ## 11. 实现前检查表
 
-- [ ] 从 `config.json` 读取所有字段，并验证 `H == Nq * D`、`Nq % Nkv == 0`。
+- [ ] 使用固定 Qwen3-8B config，并读取 GGUF metadata 验证 `H == Nq * D`、`Nq % Nkv == 0` 和全部目标尺寸。
 - [ ] HF 权重名使用 Qwen3-8B 的 `model.layers.*` 前缀，而非 Qwen3.5/3.6 的 `model.language_model.*`。
-- [ ] QKV 融合顺序是 Q → K → V，gate-up 融合顺序是 gate → up。
+- [ ] 首版 Q/K/V 和 gate/up 权重独立；若后续融合，顺序必须是 Q → K → V、gate → up，并补齐多 token 布局 helper。
 - [ ] 每层拥有独立 K/V cache；K 在 q/k norm 和 RoPE 后写入。
 - [ ] 注意力缩放为 `1/sqrt(head_dim)`，并按 4 个 Q head 共享一个 KV head 实现 GQA。
 - [ ] 两次残差加法均存在：attention 后一次，MLP 后一次。

--- a/metainfer/tasks/gen_cpp_infer_framework/notebooks/04_qwen3_z200_operator_contract.md
+++ b/metainfer/tasks/gen_cpp_infer_framework/notebooks/04_qwen3_z200_operator_contract.md
@@ -4,7 +4,7 @@
 >
 > 算子参考源码（实现事实来源）：`MetaInfer/metainfer/tasks/gen_cpp_infer_framework/notebooks/qwen3_z200_kernels.hip.cpp`
 >
-> 模型数学与权重 shape：`MetaInfer/metainfer/tasks/gen_cpp_infer_framework/notebooks/03_qwen3_8b_cpp_contract.md`
+> 模型数学与权重 shape：`MetaInfer/metainfer/tasks/gen_cpp_infer_framework/notebooks/03_qwen3_8b_contract.md`
 
 ## 0. 核心约定：矩阵乘统一调用 hipBLAS
 
@@ -32,9 +32,12 @@ Qwen3-8B 中各算子的选择如下：
 
 | 模型算子 | 是否调用 hipBLAS | 实际入口 |
 | --- | --- | --- |
-| QKV projection | 是 | `qwen3_z200_q8_linear_fp32(M=T,N=6144,K=4096)` |
+| Q projection | 是 | `qwen3_z200_q8_linear_fp32(M=T,N=4096,K=4096)` |
+| K projection | 是 | `qwen3_z200_q8_linear_fp32(M=T,N=1024,K=4096)` |
+| V projection | 是 | `qwen3_z200_q8_linear_fp32(M=T,N=1024,K=4096)` |
 | O projection | 是 | `qwen3_z200_q8_linear_fp32(M=T,N=4096,K=4096)` |
-| gate-up projection | 是 | `qwen3_z200_q8_linear_fp32(M=T,N=24576,K=4096)` |
+| gate projection | 是 | `qwen3_z200_q8_linear_fp32(M=T,N=12288,K=4096)` |
+| up projection | 是 | `qwen3_z200_q8_linear_fp32(M=T,N=12288,K=4096)` |
 | down projection | 是 | `qwen3_z200_q8_linear_fp32(M=T,N=4096,K=12288)` |
 | LM Head | 是 | `qwen3_z200_q8_linear_fp32(M=1,N=151936,K=4096)` |
 | Embedding | 否 | Q8_0 查表 kernel，只解 token 对应行 |
@@ -54,7 +57,11 @@ Qwen3-8B 中各算子的选择如下：
 - hipBLAS 处理所有带权重的线性层；
 - 先保证 prefill/decode 数值正确，再优化 decode 性能。
 
-当前源码是**正确性参考 kernel**，不是最终高性能实现。它没有 GGUF loader、模型类、buffer allocator、采样器，也没有 fused Q8_0 GEMV。这些由生成的 C++ runtime 补齐。
+> **多并发实现覆盖说明：** 上述 `B=1` 是本算子参考实现的基线，不是多请求服务的实现方式。连续批处理必须以 `09_continuous_batching_contract.md` 为准：kernel 需要接收每个 row 的 `slot_id`/`position`，KV cache、scores 和 logits 必须按 slot/row 隔离；不能让多个 host 线程并发调用当前单序列 kernel。
+
+当前源码是**正确性参考 kernel**，不是最终高性能实现。它没有 GGUF loader、模型类、buffer allocator 或完整 sampling policy，也没有 fused Q8_0 GEMV。这些由生成的 C++ runtime 补齐。源码已经提供确定性 greedy argmax primitive，但 stop、temperature、top-k/top-p 和生成状态仍由外部 sampler/engine 管理。
+
+**首版执行决策：分别调用 Q/K/V 三个 linear，并分别调用 gate/up 两个 linear。** GGUF 本来就是这些独立权重，这样输出天然是 compact 多行 tensor，可直接连接当前 norm/KV/SwiGLU kernel。fused QKV/gate-up 只作为后续优化；在补齐第 6 节 helper 前不能用于 `T>1` prefill。
 
 ## 2. 全局张量布局和 dtype
 
@@ -63,11 +70,10 @@ Qwen3-8B 中各算子的选择如下：
 | 张量 | shape | 当前 dtype |
 | --- | --- | --- |
 | hidden state | `[T, H]` | FP32 |
-| fused QKV 输出 | `[T, 6144]` | FP32 |
 | compact Q | `[T, 32, 128]` | FP32 |
 | compact K/V | `[T, 8, 128]` | FP32 |
 | attention 输出 | `[T, 32, 128]`，字节上等价于 `[T,H]` | FP32 |
-| fused gate-up 输出 | `[T, 24576]` | FP32 |
+| compact gate/up | 各自 `[T, 12288]` | FP32 |
 | SwiGLU 输出 | `[T, 12288]` | FP32 |
 | 每层 K/V cache | `[max_seq_len, 8, 128]` | FP32 |
 | logits | `[1, 151936]` | FP32 |
@@ -109,6 +115,7 @@ FP32 hidden
 | `qwen3_z200_launch_kv_cache_write` | 连续写入一层 K/V cache | FP32 cache |
 | `qwen3_z200_launch_prefill_gqa_attention` | causal prefill GQA | FP32 `[T,H]` |
 | `qwen3_z200_launch_decode_gqa_attention` | 单 token decode GQA | FP32 `[H]` |
+| `qwen3_z200_launch_greedy_sample` | 对 device logits 做确定性 argmax | device `int32_t[1]` |
 | `qwen3_z200_launch_swiglu` | `silu(gate) * up` | FP32 `[T,I]` |
 | `qwen3_z200_launch_add` | 两个数组相加 | FP32 |
 | `qwen3_z200_launch_add_inplace` | 将 src 累加到 dst | 原地 FP32 |
@@ -220,9 +227,12 @@ if (st != HIPBLAS_STATUS_SUCCESS) {
 
 | 线性层 | M | N | K | 输出 shape |
 | --- | ---: | ---: | ---: | --- |
-| fused QKV | `T` | 6144 | 4096 | `[T,6144]` |
+| Q projection | `T` | 4096 | 4096 | `[T,4096]` |
+| K projection | `T` | 1024 | 4096 | `[T,1024]` |
+| V projection | `T` | 1024 | 4096 | `[T,1024]` |
 | O projection | `T` | 4096 | 4096 | `[T,4096]` |
-| fused gate-up | `T` | 24576 | 4096 | `[T,24576]` |
+| gate projection | `T` | 12288 | 4096 | `[T,12288]` |
+| up projection | `T` | 12288 | 4096 | `[T,12288]` |
 | down projection | `T` | 4096 | 12288 | `[T,4096]` |
 | LM Head | **1** | 151936 | 4096 | `[1,151936]` |
 
@@ -347,9 +357,26 @@ qwen3_z200_launch_add_inplace(residual, branch, T * 4096, stream);
 
 SwiGLU 计算 `silu(gate) * up`。现有接口要求 `gate` 和 `up` 都是独立 compact `[T,12288]`；它不能直接正确读取 `T>1` 的 row-major fused `[T,24576]` 两个半区，相关缺口见下一节。
 
-## 6. 当前源码的两个必要布局缺口
+### 5.9 Greedy argmax
 
-Agent 必须注意：线性层输出虽然数学上可以 `split`，但 C++ 指针偏移不一定得到跨 token compact tensor。当前参考源码还没有下面两个 pack/strided helper；不补齐时 decode 的 `T=1` 可能工作，而 prefill 的 `T>1` 会读错行。
+```cpp
+qwen3_z200_launch_greedy_sample(
+    d_logits, 151936, d_next_token, stream);
+hipMemcpyAsync(
+    &next_token, d_next_token, sizeof(int32_t),
+    hipMemcpyDeviceToHost, stream);
+hipStreamSynchronize(stream);
+```
+
+- `d_logits` 是 LM Head 产生的 FP32 `[151936]`；
+- `d_next_token` 是外部 sampler 初始化时一次性分配的 device `int[1]`，不能每个 decode step 临时 `hipMalloc/hipFree`；
+- kernel 对相同最大值选择较小 token id，适合 `temperature=0` 的确定性基准；
+- stop token、temperature、top-k/top-p、repetition penalty 不属于该 kernel。需要修改 logits 的策略在未实现 GPU logit processor 前走 CPU sampler；
+- kernel、D2H copy 和 forward 使用同一条 runtime stream，确保读取的是刚产生的 logits。
+
+## 6. 可选 fused 优化的两个布局前置条件
+
+首版独立 Q/K/V 和 gate/up 路径不需要本节 helper。若后续为了减少反量化/GEMM 调度而融合权重，必须注意：线性层输出虽然数学上可以 `split`，但 C++ 指针偏移不一定得到跨 token compact tensor。当前参考源码还没有下面两个 pack/strided helper；不补齐时 decode 的 `T=1` 可能工作，而 prefill 的 `T>1` 会读错行。
 
 ### 6.1 Fused QKV 必须 split/pack
 
@@ -363,10 +390,10 @@ row 1: Q1[4096] K1[1024] V1[1024]
 
 仅令 `q = qkv + 0`、`k = qkv + 4096`、`v = qkv + 5120`，三者在 `T>1` 时都不是各自的 compact 多行数组。prefill attention 要求 compact Q，KV writer 要求 compact K/V。
 
-首版 runtime 必须选择一种方式：
+fused 优化必须选择一种方式：
 
 1. **推荐：**补一个 HIP split/pack kernel，将 fused 输出复制为 compact `Q[T,4096]`、`K[T,1024]`、`V[T,1024]`，然后调用现有 per-head norm、RoPE、KV write 和 attention；
-2. 暂时分别执行 Q、K、V 三个线性层，直接得到 compact 输出，但会增加两次完整权重解量化和 GEMM 调度。
+2. 回退到首版的 Q、K、V 三个独立线性层，直接得到 compact 输出，但会增加两次完整权重解量化和 GEMM 调度。
 
 不能只在文档或 C++ 类型中做 reshape 而不搬运数据。必须用 `T>=2` 的递增值测试验证每一行。
 
@@ -382,12 +409,12 @@ row 1: gate1[I] up1[I]
 
 现有 `qwen3_z200_launch_swiglu()` 假设 gate/up 分别 compact。对 `T>1` 仅用 `up = gate_up + I` 会让线性遍历跨入错误半区。
 
-首版 runtime 必须选择：
+fused 优化必须选择：
 
 1. 补一个 strided SwiGLU kernel，输入行 stride 为 `2I`，每行分别读 `row[0:I]` 和 `row[I:2I]`；或
 2. 先把 gate/up pack 为两个 compact buffer，再调用现有 SwiGLU。
 
-这两个布局问题是 prefill 正确性的前置条件，不属于性能优化项。
+对 fused 路径而言，这两个布局问题是 prefill 正确性的前置条件，不是可以忽略的性能细节。
 
 ## 7. 单卡完整调用顺序
 
@@ -404,6 +431,7 @@ allocate reusable FP32 activations/intermediates
 allocate decode scores workspace
 allocate x_fp16_workspace
 allocate shared weight_fp16_workspace
+create external sampler and allocate d_next_token[1]
 ```
 
 所有 workspace 只分配一次。逐层 forward 和逐 token decode 中禁止 `hipMalloc/hipFree`。
@@ -417,8 +445,9 @@ for layer = 0..35:
     residual = x
     RMSNorm(x) -> h
 
-    q8_linear(h, fused_qkv, M=T,N=6144,K=4096) -> qkv_fused
-    split/pack qkv_fused -> q_compact, k_compact, v_compact
+    q8_linear(h, q_weight, M=T,N=4096,K=4096) -> q_compact
+    q8_linear(h, k_weight, M=T,N=1024,K=4096) -> k_compact
+    q8_linear(h, v_weight, M=T,N=1024,K=4096) -> v_compact
     per_head_rms(q_compact) -> q_norm
     per_head_rms(k_compact) -> k_norm
     RoPE(q_norm, start_pos, NEOX)
@@ -431,8 +460,9 @@ for layer = 0..35:
 
     residual = x
     RMSNorm(x) -> h
-    q8_linear(h, gate_up, M=T,N=24576,K=4096) -> gate_up_fused
-    strided SwiGLU 或 pack+SwiGLU -> ffn[T,12288]
+    q8_linear(h, gate_weight, M=T,N=12288,K=4096) -> gate
+    q8_linear(h, up_weight, M=T,N=12288,K=4096) -> up
+    SwiGLU(gate, up) -> ffn[T,12288]
     q8_linear(ffn, down, M=T,N=4096,K=12288) -> down
     add(residual, down) -> x
 
@@ -450,8 +480,7 @@ current_pos = cache.length
 
 for layer = 0..35:
     attention RMSNorm
-    q8 QKV linear, M=1
-    split Q/K/V
+    q8 Q/K/V independent linears, M=1
     per-head Q/K RMSNorm
     Q/K RoPE(position=current_pos)
     write K/V at current_pos
@@ -459,18 +488,18 @@ for layer = 0..35:
     q8 O linear, M=1
     residual add
     FFN RMSNorm
-    q8 gate-up linear, M=1
+    q8 gate/up independent linears, M=1
     SwiGLU
     q8 down linear, M=1
     residual add
 
 final RMSNorm
 q8 LM Head, M=1
-sample
 cache.length = current_pos + 1
+external greedy sampler -> d_next_token[1] -> copy one int32 to host
 ```
 
-T=1 时 fused 段在单行中连续，但仍建议复用与 prefill 相同的 split/pack 接口，减少两条执行路径产生的错误。
+Runtime 在 forward 成功后提交 cache length，并把 logits 交给外部 sampler。后续若启用 fused 路径，decode 也应复用与 prefill 相同的 split/pack 接口，减少两条执行路径产生的错误。
 
 ## 8. 单卡 workspace 与显存规划
 
@@ -484,7 +513,7 @@ T=1 时 fused 段在单行中连续，但仍建议复用与 prefill 相同的 sp
 = 1187 MiB ≈ 1.159 GiB
 ```
 
-gate-up 只需 192 MiB，所以不能以 gate-up 作为全局最大值。LM Head 首版可以不分块；若启动时 `hipMemGetInfo` 显示余量不足，再沿 vocab 行分块解量化和 GEMM。
+首版独立 gate/up 每个只需 96 MiB；可选 fused gate-up 也只有 192 MiB，所以都不能作为全局最大值。LM Head 首版可以不分块；若启动时 `hipMemGetInfo` 显示余量不足，再沿 vocab 行分块解量化和 GEMM。
 
 ### 8.2 激活 workspace
 
@@ -494,9 +523,9 @@ FP32 激活/中间 buffer 应做生命周期复用，但不能让一个 kernel �
 
 - hidden/residual ping-pong `[T,H]`；
 - norm output `[T,H]`；
-- fused QKV 和 compact Q/K/V；
+- compact Q/K/V 独立输出；若启用 fused 优化，再增加 fused QKV 临时区；
 - attention/O projection `[T,H]`；
-- fused gate-up 和 SwiGLU `[T,I]`；
+- compact gate/up 和 SwiGLU `[T,I]`；若启用 fused 优化，再增加 fused gate-up 临时区；
 - logits `[V]`；
 - decode scores `[32,max_seq_len]`。
 
@@ -527,8 +556,8 @@ FP32 激活/中间 buffer 应做生命周期复用，但不能让一个 kernel �
 3. Embedding：包含重复 token，验证只返回对应行；另外测试越界由 runtime 拒绝。
 4. RMSNorm：对比 CPU reference，并分别测试 hidden `[T,4096]` 和 per-head `[T,N,128]`。
 5. RoPE：测试 `start_pos=0` 和非零位置，确认使用 `ROPE_NEOX`。
-6. QKV pack：必须用 `T>=2` 且每一行数值不同，防止 stride 错误被单 token 掩盖。
-7. gate-up/SwiGLU：必须用 `T>=2`，验证每行 gate/up 配对正确。
+6. 独立 Q/K/V：必须用 `T>=2` 且每一行数值不同，验证 compact layout；启用 fused 优化时再增加 pack stride 测试。
+7. 独立 gate/up + SwiGLU：必须用 `T>=2`，验证每行 gate/up 配对；启用 fused 优化时再增加 strided/pack 测试。
 8. KV + attention：比较 prefill 最后位置与逐 token decode 最后位置输出。
 9. 整层：比较 attention residual、FFN residual。
 10. 全模型：固定 prompt 比较最后 logits/greedy token，再做多步 decode。

--- a/metainfer/tasks/gen_cpp_infer_framework/notebooks/05_qwen3_gguf_loader_notes.md
+++ b/metainfer/tasks/gen_cpp_infer_framework/notebooks/05_qwen3_gguf_loader_notes.md
@@ -1,0 +1,619 @@
+# Qwen3-8B GGUF Loader Notes
+
+这份文档给后续 agent 参考，用来在当前小型 C++/HIP 推理框架里实现一个最小可用的 Qwen3-8B GGUF loader。
+
+先把 `Qwen3-8B-Q8_0.gguf` 的权重和必要配置读出来，接到现有 Qwen3/HIP forward 与 `qwen3_z200_kernels.hip.cpp`。
+
+## 1. 实现范围
+
+第一版只支持：
+
+- 模型架构：dense Qwen3-8B，不支持 MoE，不支持 VL，不支持 Qwen3Next。
+- GGUF 版本：优先支持 GGUF v3。
+- tensor 类型：`F32`、`F16`、`Q8_0`。
+- 权重加载：按 tensor name 建表，上传到 GPU。
+- tokenizer：从同一个 GGUF 的 metadata 构造 `Qwen3TokenizerData`，交给 `tokenizer.cpp` 的 byte-level BPE 实现。
+
+第一版不做：
+
+- 完整 GGUF 写入器。
+- 全部 quant 类型，例如 Q4_K、Q5_K、Q6_K。
+- llama.cpp 的 backend/scheduler/graph 抽象。
+- tokenizer/chat template 的完整兼容。
+
+## 2. GGUF 和当前框架的关系
+
+当前旧 loader 类似：
+
+```cpp
+read Config
+read all weights as float
+memory_map_weights(w, config, d_weight)
+```
+
+GGUF 不能这样读，因为每个 tensor 都有自己的名字、shape、type 和 offset：
+
+```text
+token_embd.weight              Q8_0 or F16/F32
+blk.0.attn_q.weight            Q8_0
+blk.0.attn_norm.weight         F32/F16
+blk.0.attn_q_norm.weight       F32/F16
+output_norm.weight             F32/F16
+output.weight                  Q8_0, required for this fixed Qwen3-8B
+```
+
+所以 GGUF loader 的核心是：
+
+```text
+解析 metadata
+解析 tensor info table
+按 tensor.name 找权重
+按 tensor.type 选择保存格式
+按 tensor.offset 读取数据并上传 GPU
+从 tokenizer metadata 构造 Qwen3TokenizerData
+```
+
+不要再生成或读取旧式 `tokenizer.bin`。Tokenizer 与权重 Loader 共用同一次 GGUF metadata 解析，Tokenizer 本身不重复打开 GGUF 文件。
+
+## 3. GGUF 文件布局
+
+GGUF 文件结构：
+
+```text
+magic:      "GGUF"   4 bytes
+version:    uint32
+n_tensors:  uint64/int64, 8 bytes
+n_kv:       uint64/int64, 8 bytes
+
+kv table:
+  key string
+  gguf_type int32
+  value bytes
+
+tensor info table:
+  name string
+  n_dims uint32
+  dims[n_dims] uint64/int64
+  ggml_type int32
+  offset uint64, relative to data blob
+
+tensor data blob:
+  starts at aligned file offset
+```
+
+String 编码：
+
+```text
+uint64 length
+length bytes, no trailing '\0'
+```
+
+默认 alignment 是 32，如果 metadata 里有 `general.alignment`，使用它：
+
+```cpp
+data_offset = align_up(current_file_offset, alignment);
+real_tensor_file_offset = data_offset + tensor.offset;
+```
+
+## 4. 需要支持的类型
+
+GGUF metadata 的 value type 是 `gguf_type`，tensor data 的类型是 `ggml_type`。不要混用这两个 enum。
+
+第一版需要的 `ggml_type`：
+
+```cpp
+enum GgmlType : int32_t {
+    GGML_TYPE_F32  = 0,
+    GGML_TYPE_F16  = 1,
+    GGML_TYPE_Q8_0 = 8,
+};
+```
+
+第一版需要的 `gguf_type`：
+
+```cpp
+enum GgufType : int32_t {
+    GGUF_TYPE_UINT8   = 0,
+    GGUF_TYPE_INT8    = 1,
+    GGUF_TYPE_UINT16  = 2,
+    GGUF_TYPE_INT16   = 3,
+    GGUF_TYPE_UINT32  = 4,
+    GGUF_TYPE_INT32   = 5,
+    GGUF_TYPE_FLOAT32 = 6,
+    GGUF_TYPE_BOOL    = 7,
+    GGUF_TYPE_STRING  = 8,
+    GGUF_TYPE_ARRAY   = 9,
+    GGUF_TYPE_UINT64  = 10,
+    GGUF_TYPE_INT64   = 11,
+    GGUF_TYPE_FLOAT64 = 12,
+};
+```
+
+Bool 在 GGUF 里按 int8 存。
+
+Array 编码：
+
+```text
+array element type: gguf_type int32
+array length:       uint64
+array data:         element bytes
+```
+
+如果 array element 是 string，每个元素仍按 `uint64 len + bytes` 读取。
+
+## 5. Q8_0 存储格式
+
+`Q8_0` 每 32 个原始元素一个 block：
+
+```cpp
+struct BlockQ8_0 {
+    half d;        // FP16 scale, 2 bytes
+    int8_t qs[32]; // 32 signed quants
+};
+```
+
+每个 block 是 34 bytes，必须和 `qwen3_z200_kernels.hip.cpp` 里的 `BlockQ8_0` byte layout 一致。
+
+Q8_0 tensor size 不能按 `numel` 算，要按 row 算：
+
+```cpp
+size_t ggml_row_size_q8_0(uint64_t ne0) {
+    // ne0 是最快维，也就是矩阵的 K 维
+    assert(ne0 % 32 == 0);
+    return (ne0 / 32) * 34;
+}
+
+size_t tensor_nbytes_q8_0(const std::vector<uint64_t> & ne) {
+    size_t rows = 1;
+    for (size_t i = 1; i < ne.size(); ++i) {
+        rows *= ne[i];
+    }
+    return rows * ggml_row_size_q8_0(ne[0]);
+}
+```
+
+F32/F16:
+
+```cpp
+numel = product(ne)
+F32 bytes = numel * 4
+F16 bytes = numel * 2
+```
+
+## 6. 建议数据结构
+
+```cpp
+enum class TensorStorage {
+    F32,
+    F16,
+    Q8_0,
+};
+
+struct GgufTensor {
+    std::string name;
+    std::vector<uint64_t> ne; // GGML order: ne[0] fastest dim
+    int32_t ggml_type;
+    uint64_t offset;          // relative to data blob
+    size_t nbytes;
+    void * d_ptr = nullptr;
+};
+
+struct Qwen3Config {
+    int dim;
+    int hidden_dim;
+    int n_layer;
+    int n_head;
+    int n_kv_head;
+    int head_dim;
+    int vocab_size;
+
+    // Runtime KV cache cap. Can be smaller than GGUF train context length.
+    int seq_len;
+
+    float rope_theta;
+    float rms_eps;
+};
+
+struct Qwen3LayerWeights {
+    GgufTensor * attn_norm;
+    GgufTensor * wq;
+    GgufTensor * wk;
+    GgufTensor * wv;
+    GgufTensor * wo;
+    GgufTensor * q_norm;
+    GgufTensor * k_norm;
+    GgufTensor * ffn_norm;
+    GgufTensor * ffn_gate;
+    GgufTensor * ffn_up;
+    GgufTensor * ffn_down;
+};
+
+struct Qwen3Weights {
+    GgufTensor * token_embd;
+    GgufTensor * output_norm;
+    GgufTensor * output; // required: tie_word_embeddings == false
+    std::vector<Qwen3LayerWeights> layers;
+};
+
+struct Qwen3GgufModel {
+    Qwen3Config config;
+    Qwen3Weights weights;
+    std::unordered_map<std::string, GgufTensor> tensors;
+
+    Qwen3GgufModel() = default;
+    ~Qwen3GgufModel();
+    Qwen3GgufModel(const Qwen3GgufModel&) = delete;
+    Qwen3GgufModel& operator=(const Qwen3GgufModel&) = delete;
+
+    Qwen3GgufModel(Qwen3GgufModel&& other) noexcept;
+    Qwen3GgufModel& operator=(Qwen3GgufModel&& other) noexcept;
+
+    // Move operations must rebind all weight views after moving tensors.
+    void rebind_weight_views();
+};
+```
+
+`Qwen3Weights` 里的指针只是指向 `tensors` 元素的 view，不拥有 device memory。model 禁止默认复制；复制 unordered map 后，view 仍可能指向旧 model。填完全部 tensor 后再调用 `rebind_weight_views()`，之后不要继续插入导致 rehash。更稳妥的实现是让 weights 保存稳定索引/名称，在访问时查 tensor。
+
+`Qwen3GgufModel` 是 GPU 权重 owner，其析构路径必须且只执行一次 `hipFree`。move 后要让源对象失去 device pointer 所有权，并在目标对象重新绑定 views，避免 double-free。`Qwen3Runtime` 只保存对 model 的非拥有引用，model 必须比 runtime 活得更久。
+
+## 7. Qwen3-8B config
+
+当前任务只支持固定 Qwen3-8B dense。Loader 读取 metadata 的目的，是验证输入文件和固定 runtime config 完全匹配；metadata 不是把 runtime 悄悄切换成其他 Qwen3 变体的配置入口。
+
+需要读取的 key：
+
+```text
+general.architecture
+qwen3.context_length
+qwen3.embedding_length
+qwen3.block_count
+qwen3.feed_forward_length
+qwen3.attention.head_count
+qwen3.attention.head_count_kv
+qwen3.attention.layer_norm_rms_epsilon
+qwen3.rope.freq_base
+qwen3.vocab_size
+```
+
+Qwen3-8B dense 固定值：
+
+```cpp
+config.dim        = 4096;
+config.hidden_dim = 12288;
+config.n_layer    = 36;
+config.n_head     = 32;
+config.n_kv_head  = 8;
+config.head_dim   = 128;       // dim / n_head
+config.vocab_size = 151936;
+config.rope_theta = 1000000.0f;
+config.rms_eps    = 1e-6f;
+```
+
+校验规则：
+
+```text
+general.architecture == "qwen3"
+embedding_length      == 4096
+feed_forward_length   == 12288
+block_count           == 36
+head_count             == 32
+head_count_kv          == 8
+vocab_size             == 151936
+rope.freq_base          ~= 1000000.0
+layer_norm_rms_epsilon  ~= 1e-6
+```
+
+整数必须精确相等；浮点 metadata 用小容差比较。关键字段缺失或不一致时打印实际值和期望值并失败，不使用另一个模型的 fallback。
+
+`seq_len` 建议作为运行时参数，不要直接等于 GGUF 的训练 context。16GB 卡上先用 2048、4096 或 8192 跑通，否则 KV cache 会很大。
+
+```cpp
+config.seq_len = std::min(user_runtime_ctx, gguf_context_length);
+```
+
+## 8. 交给 Runtime 构造的 RoPE sin/cos table
+
+RoPE table 不是 Qwen3 的大矩阵权重，不从 GGUF tensor data 里加载。Loader 只读取并校验 `qwen3.rope.freq_base`；`Qwen3Runtime::initialize()` 根据固定 config 和运行时 `max_seq_len` 在 CPU 端生成 table，再上传到 GPU。
+参考代码：
+
+```cpp
+void build_rope_table(
+        float * d_sin,
+        float * d_cos,
+        int head_dim,
+        int seq_len,
+        float rope_theta) {
+    const int half = head_dim / 2;
+    std::vector<float> sin_table((size_t) seq_len * half);
+    std::vector<float> cos_table((size_t) seq_len * half);
+
+    for (int pos = 0; pos < seq_len; ++pos) {
+        for (int j = 0; j < half; ++j) {
+            const float inv_freq = powf(rope_theta, -2.0f * j / (float) head_dim);
+            const float angle = pos * inv_freq;
+            sin_table[(size_t) pos * half + j] = sinf(angle);
+            cos_table[(size_t) pos * half + j] = cosf(angle);
+        }
+    }
+
+    hipMemcpy(d_sin, sin_table.data(), sin_table.size() * sizeof(float), hipMemcpyHostToDevice);
+    hipMemcpy(d_cos, cos_table.data(), cos_table.size() * sizeof(float), hipMemcpyHostToDevice);
+}
+```
+
+注意点：
+
+- `n_head` 不参与 RoPE table 生成，table 只和 `seq_len`、`head_dim`、`rope_theta` 有关。
+- 当前 `qwen3_z200::rope_kernel` 按 `pos * (head_dim / 2) + pair` 读取 cos/sin，所以 table shape 应该是 `[seq_len, head_dim / 2]`。
+- prefill 时位置从 `start_pos` 开始；decode 时位置是当前 token 的绝对 pos。
+- 如果后面支持 YaRN/LongRoPE，再扩展 `rope_freq_scale` 等参数；第一版 Qwen3-8B dense 先用基础 RoPE 公式。
+
+## 9. Qwen3 tensor 名称
+
+全局 tensor：
+
+```text
+token_embd.weight
+output_norm.weight
+output.weight          // required for fixed Qwen3-8B
+```
+
+每层 tensor，`%d` 是 layer index：
+
+```text
+blk.%d.attn_norm.weight
+blk.%d.attn_q.weight
+blk.%d.attn_k.weight
+blk.%d.attn_v.weight
+blk.%d.attn_output.weight
+blk.%d.attn_q_norm.weight
+blk.%d.attn_k_norm.weight
+blk.%d.ffn_norm.weight
+blk.%d.ffn_gate.weight
+blk.%d.ffn_up.weight
+blk.%d.ffn_down.weight
+```
+
+固定 Qwen3-8B 的 `tie_word_embeddings=false`。如果 `output.weight` 不存在，Loader 必须报错：
+
+```cpp
+throw std::runtime_error(
+        "missing output.weight for Qwen3-8B with untied embeddings");
+```
+
+不能 fallback 到 `token_embd.weight`；两者数学含义和训练参数不同。
+
+## 10. Tensor shape 规则
+
+GGML tensor 维度顺序是 `ne[0]` fastest dim。对于 2D linear weight：
+
+```text
+tensor.ne = {K, N}
+```
+
+在内存里可以按 row-major `W[N, K]` 理解。调用现有 Q8_0 linear 时：
+
+```cpp
+k = tensor.ne[0]; // input dim
+n = tensor.ne[1]; // output dim
+m = n_tokens;
+```
+
+Qwen3 dense 主要 shape：
+
+```text
+token_embd.weight              {dim, vocab_size}
+output_norm.weight             {dim}
+output.weight                  {dim, vocab_size}
+
+blk.i.attn_norm.weight         {dim}
+blk.i.attn_q.weight            {dim, n_head * head_dim}
+blk.i.attn_k.weight            {dim, n_kv_head * head_dim}
+blk.i.attn_v.weight            {dim, n_kv_head * head_dim}
+blk.i.attn_output.weight       {n_head * head_dim, dim}
+blk.i.attn_q_norm.weight       {head_dim}
+blk.i.attn_k_norm.weight       {head_dim}
+
+blk.i.ffn_norm.weight          {dim}
+blk.i.ffn_gate.weight          {dim, hidden_dim}
+blk.i.ffn_up.weight            {dim, hidden_dim}
+blk.i.ffn_down.weight          {hidden_dim, dim}
+```
+
+对应现有 forward 的线性层：
+
+```text
+Q:       x[*, dim]        * attn_q.weight       -> [*, n_head * head_dim]
+K:       x[*, dim]        * attn_k.weight       -> [*, n_kv_head * head_dim]
+V:       x[*, dim]        * attn_v.weight       -> [*, n_kv_head * head_dim]
+O:       attn[*, dim]     * attn_output.weight  -> [*, dim]
+gate:    x[*, dim]        * ffn_gate.weight     -> [*, hidden_dim]
+up:      x[*, dim]        * ffn_up.weight       -> [*, hidden_dim]
+down:    swiglu[*, hdim]  * ffn_down.weight     -> [*, dim]
+lm_head: x[*, dim]        * output.weight       -> [*, vocab_size]
+```
+
+## 11. 类型分发策略
+
+loader 必须保留 tensor 的 `ggml_type`。
+
+```cpp
+if (tensor.type == GGML_TYPE_Q8_0) {
+    // Keep bytes as BlockQ8_0 on GPU.
+    // Linear uses qwen3_z200_q8_linear_fp32.
+}
+
+if (tensor.type == GGML_TYPE_F32) {
+    // Upload as float.
+    // Norm weights can be used directly by RMSNorm kernels.
+}
+
+if (tensor.type == GGML_TYPE_F16) {
+    // Option A: convert to float on CPU, upload float for norm kernels.
+    // Option B: keep half and add F16-aware norm kernels later.
+    // First version should convert 1D norm weights to float.
+}
+```
+
+重要：`Qwen3-8B-Q8_0.gguf` 不是所有 tensor 都是 Q8_0。通常大矩阵是 Q8_0，norm 这类 1D tensor 是 F16/F32。不能把 norm 权重当 `BlockQ8_0` 读。
+
+## 12. 加载流程建议
+
+```cpp
+Qwen3GgufModel load_qwen3_gguf(
+        const std::string & path,
+        int runtime_ctx,
+        hipStream_t stream) {
+    open file
+    read header
+    read kv metadata
+    read tensor infos
+    compute data_offset
+    construct fixed Qwen3-8B config
+    validate GGUF metadata exactly matches the fixed config
+    fill Qwen3TokenizerData from tokenizer.ggml.* metadata
+    tokenizer.load(tokenizer_data)
+    validate architecture == "qwen3"
+    validate config roughly matches Qwen3-8B
+    leave RoPE table construction to Qwen3Runtime initialization
+
+    for each tensor:
+        compute nbytes by type and shape
+        seek(data_offset + tensor.offset)
+        read host bytes
+        maybe convert F16 1D norm -> F32
+        hipMalloc tensor.d_ptr
+        hipMemcpy host -> device
+
+    map_required_qwen3_tensors(model)
+    rebind/validate all tensor views after the tensor map is stable
+    validate all required tensors exist
+    return model
+}
+```
+
+建议先分两步写：
+
+1. `parse_gguf_meta(path)`：只打印 metadata 和 tensor table，不上传 GPU。
+2. `load_qwen3_gguf(path)`：在确认名字/shape/type 都对后，再做 GPU 上传和权重映射。
+
+## 13. 验证 checklist
+
+加载后先打印：
+
+```text
+architecture = qwen3
+dim = 4096
+n_layer = 36
+n_head = 32
+n_kv_head = 8
+head_dim = 128
+hidden_dim = 12288
+vocab_size = 151936
+rope_theta = 1000000
+rms_eps = 1e-6
+runtime seq_len = ...
+```
+
+每层检查：
+
+```cpp
+attn_norm.ne == {dim}
+wq.ne        == {dim, n_head * head_dim}
+wk.ne        == {dim, n_kv_head * head_dim}
+wv.ne        == {dim, n_kv_head * head_dim}
+wo.ne        == {n_head * head_dim, dim}
+q_norm.ne    == {head_dim}
+k_norm.ne    == {head_dim}
+ffn_norm.ne  == {dim}
+ffn_gate.ne  == {dim, hidden_dim}
+ffn_up.ne    == {dim, hidden_dim}
+ffn_down.ne  == {hidden_dim, dim}
+```
+
+类型检查：
+
+```cpp
+is_matrix(t) -> allow Q8_0/F16/F32
+is_norm(t)   -> require F32 or F16, then expose as float*
+```
+
+RoPE 检查：
+
+```cpp
+head_dim == dim / n_head
+rope_table_elements == runtime_seq_len * head_dim / 2
+rope_theta == value from qwen3.rope.freq_base
+```
+
+## 14. 和现有 kernel 的对接
+
+当前 `qwen3_z200_kernels.hip.cpp` 已经有：
+
+```text
+Q8_0 embedding lookup
+Q8_0 dequant to FP16
+Q8_0 linear wrapper: qwen3_z200_q8_linear_fp32
+RMSNorm
+Q/K per-head RMSNorm
+RoPE
+KV cache write
+prefill GQA attention
+decode GQA attention
+SwiGLU
+add/add_inplace
+greedy argmax sampler primitive
+```
+
+当前 kernel 文件已经导出 `qwen3_z200_launch_greedy_sample()`。Loader 不调用采样器；runtime forward 产出 `[151936]` FP32 device logits 后，由外部 sampler 在同一条 HIP stream 上调用 GPU argmax，并只把一个 token id 拷回 CPU。完整 logits 复制只用于 top-k/top-p、repetition penalty 或 correctness 调试。
+
+loader 只负责把 tensor 指针准备好。forward 根据 tensor type 选择：
+
+```cpp
+if (weight.type == Q8_0) {
+    qwen3_z200_q8_linear_fp32(...);
+} else if (weight.type == F16/F32) {
+    // Later: hipBLAS GEMM directly, or convert once.
+}
+```
+
+Norm 权重给 `qwen3_z200_launch_rms_norm` 和 `qwen3_z200_launch_per_head_rms_norm` 时，第一版最好统一成 device float pointer。
+
+## 15. 常见坑
+
+- 不要把 GGUF 的 `gguf_type` 当 tensor 的 `ggml_type`。
+- 不要假设 `Q8_0.gguf` 里所有 tensor 都是 Q8_0。
+- Q8_0 不能按 `numel` 字节读，要按 row size 读。
+- tensor offset 是相对 data blob，不是相对文件开头。
+- data blob 起点要按 `general.alignment` 对齐。
+- `seq_len` 是运行时 KV cache 上限，不一定等于 `qwen3.context_length`。
+- 固定 Qwen3-8B 的 `tie_word_embeddings=false`，`output.weight` 缺失必须报错，不能 fallback 到 `token_embd.weight`。
+- GGML 2D shape `{K, N}` 在 GEMM 里对应 row-major `W[N, K]`。
+- F16 norm 权重如果不转换，现有 float RMSNorm kernel 会读错。
+- RoPE 不要硬编码 `10000.0f`；Qwen3-8B 要用 `qwen3.rope.freq_base`，通常是 `1000000.0f`。
+
+## 16. Tokenizer metadata 交接
+
+GGUF parser 读取完 metadata 后，应构造 `tokenizer.hpp` 定义的：
+
+```cpp
+Qwen3TokenizerData tokenizer_data;
+tokenizer_data.model          = get_string("tokenizer.ggml.model");
+tokenizer_data.pre_tokenizer  = get_string("tokenizer.ggml.pre");
+tokenizer_data.tokens         = get_string_array("tokenizer.ggml.tokens");
+tokenizer_data.merges         = get_string_array("tokenizer.ggml.merges");
+tokenizer_data.token_types    = get_i32_array("tokenizer.ggml.token_type");
+tokenizer_data.bos_token_id   = get_optional_i32("tokenizer.ggml.bos_token_id", -1);
+tokenizer_data.eos_token_id   = get_optional_i32("tokenizer.ggml.eos_token_id", -1);
+tokenizer_data.pad_token_id   = get_optional_i32("tokenizer.ggml.padding_token_id", -1);
+tokenizer_data.add_bos_token  = get_optional_bool("tokenizer.ggml.add_bos_token", false);
+
+Qwen3Tokenizer tokenizer;
+std::string tokenizer_error;
+if (!tokenizer.load(tokenizer_data, &tokenizer_error)) {
+    throw std::runtime_error(tokenizer_error);
+}
+```
+
+第一版必须校验 `tokenizer.ggml.model == "gpt2"`，并确保每个 token id 小于 embedding 的 `vocab_size=151936`。Tokenizer token 数可以小于 padded embedding 行数，不能要求二者严格相等。

--- a/metainfer/tasks/gen_cpp_infer_framework/notebooks/06_qwen3_runtime_notes.md
+++ b/metainfer/tasks/gen_cpp_infer_framework/notebooks/06_qwen3_runtime_notes.md
@@ -1,0 +1,1112 @@
+# Qwen3-8B Runtime Notes Without GGML
+
+这份文档给后续 agent 参考，用来实现一个不依赖 GGML 的 Qwen3-8B 推理 runtime。
+
+前一份 `05_qwen3_gguf_loader_notes.md` 解决“权重、固定 config 校验和 tokenizer metadata 怎么从 GGUF 读出来”。这份文档解决“模型加载后，token ids 怎么跑 prefill，decode 怎么循环，KV cache 怎么维护，sampler/tokenizer 怎么接起来”。最终 HTTP 暴露方式见 `07_qwen3_http_server_contract.md`。
+
+> **多并发实现覆盖说明：** 本文的 `Qwen3RuntimeState`、`reset() -> prefill() -> decode()` 和单份 sampler/KV cache 都是 B=1 的 bring-up 契约。实现多 HTTP 请求 continuous batching 时，必须改读 `09_continuous_batching_contract.md`：它定义 scheduler 是唯一 GPU 调用者、每请求 `SequenceState`/`slot_id`、batched runtime 接口和 kernel 改造要求。不要只移除 mutex 后并行调用本文的单序列 runtime。
+
+目标是一个固定 Qwen3 dense text model 的小型 C++/HIP runtime，不做通用计算图框架。
+
+## 1. Runtime 的职责
+
+Runtime 负责：
+
+- 持有固定 Qwen3-8B config 和对模型权重的非拥有引用。
+- 创建 HIP stream、hipBLAS handle。
+- 分配中间 activation buffers。
+- 分配每层 KV cache。
+- 生成 RoPE sin/cos table。
+- 执行 prefill forward。
+- 执行 decode forward。
+- 维护初始化/有效状态、`current_pos`、KV cache 有效性和最后一轮 logits 是否可读。
+
+Runtime 不负责：
+
+- GGUF 二进制格式解析细节。
+- tokenizer/chat template。
+- greedy、top-k、top-p 等采样策略。
+- HTTP 请求/响应。
+- 通用 tensor graph。
+- GGML backend scheduler。
+- 多请求调度、paged KV、prefix cache。
+- 训练、autograd。
+
+## 2. 和现有代码的关系
+
+当前旧代码的结构大概是：
+
+```text
+main.cu
+  load_data()
+  tokenizer
+  LlamaInference engine
+  prefill
+  external sampler
+  decode loop
+
+llama_forward.cu
+  LlamaInference::forward(...)
+
+loadmodel.cu
+  Config + float weights + RoPE table
+```
+
+新的 Qwen3 runtime 可以替代这些职责：
+
+```text
+05_qwen3_gguf_loader_notes.md
+  -> Qwen3GgufModel: config + typed weights
+
+06_qwen3_runtime_notes.md
+  -> Qwen3Runtime: buffers + KV cache + prefill/decode + logits
+
+qwen3_z200_kernels.hip.cpp
+  -> actual kernels and hipBLAS Q8_0 linear wrapper
+
+tokenizer.hpp / tokenizer.cpp
+  -> existing Qwen3 byte-level BPE + single-turn chat prompt
+
+07_qwen3_http_server_contract.md
+  -> Qwen3Engine + sampler + OpenAI-compatible HTTP server
+```
+
+建议新增文件：
+
+```text
+qwen3_runtime.h
+qwen3_runtime.cpp or qwen3_runtime.hip.cpp
+qwen3_sampler.h
+```
+
+第一版也可以先把 runtime 写到一个 `.cpp/.hip.cpp` 里，跑通后再拆。
+
+## 3. 总体流程
+
+完整生成流程：
+
+```text
+load GGUF
+read Qwen3 config
+map weights
+allocate runtime buffers
+build RoPE table
+
+prompt text
+  -> tokenizer CPU, or directly provide token ids
+  -> prefill(token_ids)
+  -> logits for last prompt token
+  -> sample next token
+
+while not stop:
+  token id
+    -> decode(token id)
+    -> logits
+    -> sample next token
+    -> detokenize and print
+```
+
+最小版可以跳过 tokenizer：
+
+```text
+std::vector<int32_t> prompt_ids = { ... };
+runtime.prefill(prompt_ids.data(), prompt_ids.size(), &error);
+Qwen3Sampler sampler(runtime.stream(), model.config().vocab_size);
+CHECK_SAMPLER(sampler.initialize(&error));
+const int32_t effective_max_new_tokens = std::min<int32_t>(
+        max_new_tokens,
+        runtime.max_seq_len() - runtime.current_pos());
+for (int generated = 0; generated < effective_max_new_tokens; ++generated) {
+    int32_t next = -1;
+    CHECK_SAMPLER(sampler.sample(
+            runtime, sparams, generated_ids, &next, &error));
+    if (is_stop_token(next)) break;
+    if (generated + 1 == effective_max_new_tokens) break;
+    runtime.decode(next, &error);
+}
+```
+
+## 4. Qwen3Runtime 建议接口
+
+```cpp
+struct RuntimeConfig {
+    int32_t max_seq_len = 4096;
+    int32_t max_prefill_tokens = 128;
+};
+
+struct Qwen3RuntimeState {
+    int32_t current_pos = 0;
+    int32_t n_prompt = 0;
+    bool initialized = false;
+    bool valid = false;
+    bool has_logits = false;
+};
+
+class Qwen3Runtime {
+public:
+    // model must outlive Qwen3Runtime. Runtime does not own or copy weights.
+    explicit Qwen3Runtime(Qwen3GgufModel& model, RuntimeConfig runtime_cfg);
+    ~Qwen3Runtime();
+
+    Qwen3Runtime(const Qwen3Runtime&) = delete;
+    Qwen3Runtime& operator=(const Qwen3Runtime&) = delete;
+
+    bool initialize(std::string* error);
+    void reset();
+
+    // Both functions only run model forward and update d_logits.
+    // Sampling is an external CPU/GPU component.
+    bool prefill(const int32_t* token_ids, size_t n_tokens, std::string* error);
+    bool decode(int32_t token_id, std::string* error);
+
+    // device_logits() is readable only when has_logits() is true.
+    const float* device_logits() const { return d_logits_; }
+    hipStream_t stream() const { return stream_; }
+    int32_t current_pos() const { return state_.current_pos; }
+    int32_t n_prompt() const { return state_.n_prompt; }
+    int32_t max_seq_len() const { return runtime_cfg_.max_seq_len; }
+    bool initialized() const { return state_.initialized; }
+    bool valid() const { return state_.valid; }
+    bool has_logits() const { return state_.has_logits; }
+
+private:
+    bool allocate_buffers(std::string* error);
+    bool build_rope_table(std::string* error);
+    bool forward_tokens(
+            const int32_t* host_token_ids,
+            int32_t n_tokens,
+            int32_t start_pos,
+            bool produce_logits,
+            std::string* error);
+
+    Qwen3GgufModel& model_;
+    RuntimeConfig runtime_cfg_;
+    Qwen3RuntimeState state_;
+    hipStream_t stream_ = nullptr;
+    float* d_logits_ = nullptr;
+};
+```
+
+不要让构造函数按值接收 `Qwen3GgufModel`。`Qwen3Weights` 中保存了指向模型 tensor map 元素的指针，复制 model 后这些指针可能仍指向原对象。首版用非拥有引用最简单，并明确要求 `Qwen3GgufModel` 比 runtime 活得更久。
+
+若希望 runtime 独占模型，应使用 move-only owner（例如 `std::unique_ptr<Qwen3GgufModel>`），并保证移动后重新建立或验证所有 tensor 指针，不能依赖默认复制。
+
+Sampler 接口独立：
+
+```cpp
+struct SamplingParams {
+    int32_t max_new_tokens = 128;
+    int32_t top_k = 40;
+    float top_p = 1.0f;
+    float temperature = 0.0f;
+    float repetition_penalty = 1.0f;
+    uint64_t seed = 0;
+    std::vector<int32_t> stop_token_ids;
+};
+
+int32_t sample_logits(
+        const std::vector<float>& host_logits,
+        const SamplingParams& params,
+        const std::vector<int32_t>& generated_tokens);
+
+class Qwen3Sampler {
+public:
+    Qwen3Sampler(hipStream_t stream, int32_t vocab_size);
+    ~Qwen3Sampler();
+
+    bool initialize(std::string* error); // allocate d_next_token once
+    bool sample(
+            const Qwen3Runtime& runtime,
+            const SamplingParams& params,
+            const std::vector<int32_t>& generated_tokens,
+            int32_t* out_token,
+            std::string* error);
+
+private:
+    hipStream_t stream_ = nullptr; // same stream as runtime.stream()
+    int32_t vocab_size_ = 0;
+    int* d_next_token_ = nullptr;
+    std::vector<float> h_logits_; // only used by the CPU policy/debug path
+};
+```
+
+`stream()` 是给同一进程内的外部 sampler 建立顺序依赖用的受控 accessor。Sampler 不创建第二条不相关的 stream，也不修改 runtime 状态；它只在 runtime stream 上消费 `device_logits()`。若实现者不希望公开裸 stream，也可以提供等价的 `greedy_sample()` / `copy_logits_to_host()` 受控方法，但公开接口必须闭合，不能在伪代码中使用未声明的 `stream`。
+
+`Qwen3Sampler` 由 `Qwen3Engine` 初始化一次并跨请求复用；`sample()` 应校验 `stream_ == runtime.stream()`、`runtime.has_logits()`、`vocab_size_` 一致和 `out_token != nullptr`。不要在生成循环中重复分配 `d_next_token_` 或 `h_logits_`。
+
+## 5. 必要状态
+
+`Qwen3RuntimeState` 已在上一节的接口中定义，只保存 forward 必需状态。生命周期约束为：
+
+```text
+constructor: initialized=false, valid=false, has_logits=false
+initialize success: initialized=true, valid=true, has_logits=false
+prefill success: n_prompt=prompt length, current_pos=n_prompt, has_logits=true
+decode success: current_pos += 1, has_logits=true
+forward failure: valid=false, has_logits=false
+reset after initialize: current_pos=0, n_prompt=0, valid=true, has_logits=false
+```
+
+`prefill()` 只接受一个新的逻辑请求，要求 `initialized && valid && current_pos == 0`。`decode()` 要求 `initialized && valid && has_logits && current_pos > 0`。这样可以阻止未初始化 forward、在旧请求后直接再次 prefill，以及读取上一轮残留 logits。
+
+`current_pos` 是当前 decode 要写入 KV cache 的绝对位置。
+
+例子：
+
+```text
+prompt length = 5
+prefill writes KV positions 0,1,2,3,4
+after prefill: current_pos = 5
+
+decode token A writes KV position 5
+after decode: current_pos = 6
+
+decode token B writes KV position 6
+after decode: current_pos = 7
+```
+
+不要把 `seq_len`、`n_tokens`、`current_pos` 混在一起：
+
+```text
+max_seq_len:  KV cache 总容量
+n_tokens:     当前 forward 输入 token 数
+current_pos:  当前新 token 在整段序列里的绝对位置
+```
+
+`generated_tokens` 属于上层 `Qwen3Engine`/sampler，不属于模型 forward 状态。`reset()` 至少执行：
+
+```cpp
+state_.current_pos = 0;
+state_.n_prompt = 0;
+state_.valid = true;
+state_.has_logits = false;
+```
+
+`reset()` 只能在 `initialize()` 成功后调用，并保留 `state_.initialized=true`。不必清零整块 KV cache：后续 attention 只允许读取 `0 .. current_pos`，旧位置之外的数据不可见。调试模式可以填 NaN 帮助发现越界读取。
+
+## 6. Config
+
+当前任务只支持固定 Qwen3-8B dense，因此以下值是 runtime 的编译期/初始化真值，不是模糊 fallback：
+
+```cpp
+dim        = 4096;
+hidden_dim = 12288;
+n_layer    = 36;
+n_head     = 32;
+n_kv_head  = 8;
+head_dim   = 128;
+vocab_size = 151936;
+rope_theta = 1000000.0f;
+rms_eps    = 1e-6f;
+```
+
+Loader 仍然读取对应 GGUF metadata，但用途是逐项校验模型确实是目标 Qwen3-8B。任一关键值不一致就报错退出，不能悄悄把 runtime 改成另一个模型配置。
+
+运行时 `max_seq_len` 不一定等于 GGUF 的训练 context。16GB 卡上先用：
+
+```text
+2048 or 4096
+```
+
+跑通后再放大。
+
+## 7. Device Buffers
+
+第一版使用 FP32 activation，权重按 GGUF 类型保存。
+
+按 `max_tokens = max_prefill_tokens` 分配：
+
+```text
+d_token_ids     [max_tokens]
+d_residual      [max_tokens, dim]
+d_xb            [max_tokens, dim]
+d_q             [max_tokens, n_head, head_dim]
+d_k             [max_tokens, n_kv_head, head_dim]
+d_v             [max_tokens, n_kv_head, head_dim]
+d_q_norm        [max_tokens, n_head, head_dim]
+d_k_norm        [max_tokens, n_kv_head, head_dim]
+d_attn          [max_tokens, n_head, head_dim]
+d_attn_proj     [max_tokens, dim]
+d_gate          [max_tokens, hidden_dim]
+d_up            [max_tokens, hidden_dim]
+d_swiglu        [max_tokens, hidden_dim]
+d_ffn_out       [max_tokens, dim]
+d_logits        [vocab_size]
+d_scores        [n_head, max_seq_len] for decode scratch
+d_sin_table     [max_seq_len, head_dim / 2]
+d_cos_table     [max_seq_len, head_dim / 2]
+```
+
+注意：不要按 `max_seq_len` 分配所有 activation。旧代码里很多 buffer 是 `max_seq_len * dim`，Qwen3-8B 会浪费很多显存。activation 只需要覆盖当前 forward 的 token 数。
+
+朴素 prefill attention 是 `O(T^2)` 正确性 kernel。首版 bring-up 推荐先用：
+
+```cpp
+max_prefill_tokens = 64; // or 128
+```
+
+确认数值正确后再尝试 512/1024，并根据 activation 预算和实测耗时决定。prompt 更长时使用 chunked prefill，而不是按整个 `max_seq_len` 分配所有 activation。
+
+## 8. KV Cache
+
+Qwen3 是 GQA，KV cache 只需要 KV head，不需要 Q head。
+
+```cpp
+kv_dim = n_kv_head * head_dim;
+```
+
+每层 KV cache：
+
+```text
+K: [max_seq_len, n_kv_head, head_dim]
+V: [max_seq_len, n_kv_head, head_dim]
+```
+
+总大小：
+
+```cpp
+kv_bytes = n_layer * 2 * max_seq_len * n_kv_head * head_dim * sizeof(float);
+```
+
+不要用：
+
+```cpp
+n_layer * 2 * max_seq_len * dim
+```
+
+因为 `dim = n_head * head_dim`，而 KV 只需要 `n_kv_head * head_dim`。对 Qwen3-8B：
+
+```text
+dim = 4096
+kv_dim = 8 * 128 = 1024
+```
+
+用 `dim` 分配会多 4 倍。
+
+第一版 KV cache 用 FP32，直接适配当前 attention kernels。后面要省显存，可以改 FP16 KV cache，同时修改 attention kernel 的读类型。
+
+`max_seq_len=4096` 时的精确占用为：
+
+```text
+2 * 36 * 4096 * 8 * 128 * 4 bytes
+= 1,207,959,552 bytes
+= 1.125 GiB
+```
+
+Runtime 初始化时必须用 `size_t` 计算所有乘积，并调用 `hipMemGetInfo()` 打印模型、KV、workspace、activation 和剩余显存。任何配置超出安全预算时应在启动阶段拒绝，而不是等逐层 forward 才 OOM。
+
+## 9. RoPE Table
+
+Runtime 初始化时生成：
+
+```cpp
+build_rope_table(d_sin_table, d_cos_table, head_dim, max_seq_len, rope_theta);
+```
+
+Qwen3-8B 不要硬编码 `10000.0f`，要用：
+
+```text
+qwen3.rope.freq_base
+```
+
+常见是：
+
+```cpp
+rope_theta = 1000000.0f;
+```
+
+table shape：
+
+```text
+[max_seq_len, head_dim / 2]
+```
+
+调用现有 RoPE kernel 时必须显式使用 Qwen3 的 half-split 语义：
+
+```cpp
+rope_mode = ROPE_NEOX; // value 1 in the current kernel contract
+q_row_stride = n_head * head_dim;       // 4096
+k_row_stride = n_kv_head * head_dim;    // 1024
+```
+
+每次调用前检查：
+
+```cpp
+start_pos >= 0
+n_tokens > 0
+start_pos + n_tokens <= max_seq_len
+start_pos + n_tokens <= rope_table_positions
+```
+
+## 10. Prefill Forward
+
+输入：
+
+```text
+token_ids: [n_tokens]
+start_pos: usually 0 for first prompt
+```
+
+公开接口接收 host token ids。`forward_tokens()` 首先把当前 chunk 精确复制到初始化时分配的 `d_token_ids`，然后再调用 embedding：
+
+```cpp
+hipMemcpyAsync(
+    d_token_ids,
+    host_token_ids,
+    n_tokens * sizeof(int32_t),
+    hipMemcpyHostToDevice,
+    stream);
+```
+
+caller 的 host buffer 只需活到该异步复制被当前 stream 完成；首版 forward 末尾会同步 stream。不要把 host 指针误当 device pointer 直接传给 embedding kernel。
+
+步骤：
+
+```cpp
+embedding_lookup(token_ids) -> residual [n_tokens, dim]
+
+for layer in layers:
+    rms_norm(xb, residual, attn_norm, n_tokens, dim, rms_eps)
+
+    q = linear(xb, attn_q)       // [n_tokens, n_head * head_dim]
+    k = linear(xb, attn_k)       // [n_tokens, n_kv_head * head_dim]
+    v = linear(xb, attn_v)       // [n_tokens, n_kv_head * head_dim]
+
+    per_head_rms_norm(q_norm, q, q_norm_weight)
+    per_head_rms_norm(k_norm, k, k_norm_weight)
+
+    rope(q_norm, start_pos, ROPE_NEOX)
+    rope(k_norm, start_pos, ROPE_NEOX)
+
+    kv_cache_write(k_norm, v, layer_cache, start_pos)
+
+    prefill_gqa_attention(
+        q_norm, K_cache, V_cache, attn,
+        n_tokens, start_pos,
+        scale=1.0f/sqrtf(head_dim))
+
+    attn_proj = linear(attn, attn_output)
+    residual += attn_proj
+
+    rms_norm(xb, residual, ffn_norm, n_tokens, dim, rms_eps)
+
+    gate = linear(xb, ffn_gate)
+    up   = linear(xb, ffn_up)
+    swiglu = silu(gate) * up
+    ffn_out = linear(swiglu, ffn_down)
+
+    residual += ffn_out
+
+last_residual = residual + (n_tokens - 1) * dim
+final_norm(xb, last_residual, output_norm, rows=1, dim=dim)
+lm_head(xb, M=1) -> logits [vocab_size]
+```
+
+Qwen3 特别注意：
+
+- Q/K projection 后有 per-head RMSNorm。
+- Q/K norm 在 RoPE 前。
+- Attention 是 GQA：`n_head > n_kv_head`。
+- Attention scale 固定为 `1.0f / sqrtf(128.0f)`。
+- 当前 norm kernel 按输入/输出不 alias 使用，`q_norm`、`k_norm` 需要独立 buffer。
+- LM head 只需要最后一个 token 的 hidden state。`last_residual` 必须显式指向最终 layer 输出的最后一行；final RMSNorm 把这一行写入 `d_xb[0:dim]`，LM Head 再以 `d_xb` 为 `M=1` 输入，不能使用未定义的 `last_token_hidden`。
+
+首版 runtime 明确选择分别执行 Q、K、V 三个 linear，以及分别执行 gate、up 两个 linear。这样直接得到 compact 多行 tensor，能使用当前 per-head norm、KV writer 和 SwiGLU kernel，不需要尚未实现的 fused split/pack/strided helper。代价是多几次整块反量化和 GEMM；这是首版正确性换性能的明确决策。
+
+Prefill 完成后：
+
+```cpp
+state_.current_pos = start_pos + n_tokens;
+state_.has_logits = produce_logits;
+```
+
+只有当前调用要求的工作和必要的 stream 错误检查都成功后，才能提交 `current_pos`：所有 chunk 都必须完成 36 层；`produce_logits=true` 的最后一个 chunk 还必须完成 final norm 和 LM Head。`produce_logits=false` 的非末 chunk 不执行这两个算子，因此不能把它们写成所有 chunk 的提交前置条件。
+
+公开 `prefill()` 完成全部 chunk 后还要提交：
+
+```cpp
+state_.n_prompt = static_cast<int32_t>(total_prompt_tokens);
+state_.has_logits = true; // final chunk produced logits
+```
+
+进入每次 forward 时先令 `state_.has_logits=false`，防止异步执行期间或失败后读取旧 logits。中途失败时保留旧 `current_pos`，同时设置：
+
+```cpp
+state_.valid = false;
+state_.has_logits = false;
+```
+
+虽然重试可能覆盖部分 KV，但不同层可能已经写入不同进度；首版不要在失败状态上继续 decode，必须 `reset()` 后从 prompt 重新 prefill。
+
+## 11. Decode Forward
+
+输入：
+
+```text
+token_id: one token
+start_pos = current_pos
+n_tokens = 1
+```
+
+步骤和 prefill 类似，但 attention 用 decode kernel：
+
+```cpp
+embedding_lookup(token_id) -> residual [1, dim]
+
+for layer in layers:
+    rms_norm
+    separate q/k/v linear
+    q/k per-head rms_norm -> q_norm/k_norm
+    rope(q_norm, current_pos, ROPE_NEOX)
+    rope(k_norm, current_pos, ROPE_NEOX)
+    kv_cache_write(k_norm, v, position=current_pos)
+    decode_gqa_attention(
+        q_norm, K_cache, V_cache, current_pos,
+        scale=1.0f/sqrtf(head_dim))
+    output projection
+    residual add
+    ffn
+    residual add
+
+final norm
+lm_head -> logits
+if the complete forward succeeded:
+    current_pos += 1
+    has_logits = true
+else:
+    state.valid = false
+    state.has_logits = false
+```
+
+Decode 的 attention 是：
+
+```text
+Q: one token
+K/V: positions [0 ... current_pos]
+```
+
+所以 decode 本质更像 GEMV/scan，不是大 GEMM。
+
+## 12. Linear 调用策略
+
+对 Q8_0 权重：
+
+```cpp
+qwen3_z200_q8_linear_fp32(
+    handle,
+    out,
+    x,
+    weight_q8,
+    x_fp16_workspace,
+    x_workspace_elements,
+    weight_fp16_workspace,
+    weight_workspace_elements,
+    m,
+    n,
+    k,
+    stream);
+```
+
+其中：
+
+```text
+x:      [m, k]
+weight: GGML shape {k, n}, memory can be viewed as row-major W[n, k]
+out:    [m, n]
+```
+
+常见参数：
+
+```text
+attn_q:        m=n_tokens, n=n_head*head_dim,    k=dim
+attn_k:        m=n_tokens, n=n_kv_head*head_dim, k=dim
+attn_v:        m=n_tokens, n=n_kv_head*head_dim, k=dim
+attn_output:   m=n_tokens, n=dim,                k=n_head*head_dim
+ffn_gate:      m=n_tokens, n=hidden_dim,         k=dim
+ffn_up:        m=n_tokens, n=hidden_dim,         k=dim
+ffn_down:      m=n_tokens, n=dim,                k=hidden_dim
+lm_head:       m=1,        n=vocab_size,         k=dim
+```
+
+第一版可以用一个全局 workspace 复用：
+
+```text
+x_workspace_elements
+    = max_prefill_tokens * max(dim, hidden_dim)
+    = max_prefill_tokens * 12288 FP16 elements
+
+weight_workspace_elements
+    = vocab_size * dim
+    = 151936 * 4096
+    = 622,329,856 FP16 elements
+```
+
+显存提醒：
+
+- 现在的 Q8_0 linear 是“整块权重反量化到 FP16 workspace 再 hipBLAS”。
+- `lm_head/output.weight` 的 FP16 workspace 是 `1,244,659,712 bytes = 1187 MiB ~= 1.159 GiB`。
+- 所有元素数和 byte 数使用 `size_t`，分配时再乘 `sizeof(__half)`，不要用 32-bit `int` 计算。
+- 初始化阶段调用 `hipMemGetInfo()`；若完整 LM Head workspace 分配失败，再实现沿 vocab 行分块，不能静默分配更小 workspace 后继续调用。
+- 如果 16GB 压力大，后面需要 fused Q8_0 GEMV/GEMM 或 tiled dequant GEMM，不能每次整块 dequant。
+
+同一个 `weight_fp16_workspace` 只能串行复用。cast、dequant、hipBLAS GEMM 和消费 GEMM 输出的后续 kernel 必须进入同一条 HIP stream，或者用 event 建立显式依赖。首版只创建一条 stream，并执行：
+
+```cpp
+hipblasSetStream(handle, stream);
+```
+
+禁止两个 linear 并发使用共享 workspace，也不要在另一个线程同时修改同一 hipBLAS handle 的 stream 或 pointer mode。逐层路径中禁止 `hipMalloc/hipFree`；所有 workspace 在初始化时分配一次。
+
+## 13. Sampler
+
+当前 `qwen3_z200_kernels.hip.cpp` 已导出：
+
+```cpp
+extern "C" hipError_t qwen3_z200_launch_greedy_sample(
+        const float* logits,
+        int vocab_size,
+        int* out_token,
+        hipStream_t stream);
+```
+
+首版 `temperature == 0` 且没有 repetition penalty 等 logit processor 时，直接用这个 GPU argmax；确定性模式下忽略 `top_k/top_p`。Sampler 初始化时一次性分配 `d_next_token[1]`，析构时释放；每轮只把一个 `int32_t` 拷回 CPU：
+
+```cpp
+if (!runtime.has_logits()) {
+    return set_error(error, "runtime has no readable logits");
+}
+
+CHECK_HIP(qwen3_z200_launch_greedy_sample(
+        runtime.device_logits(),
+        vocab_size,
+        d_next_token,
+        runtime.stream()));
+CHECK_HIP(hipMemcpyAsync(
+        &next_token,
+        d_next_token,
+        sizeof(int32_t),
+        hipMemcpyDeviceToHost,
+        runtime.stream()));
+CHECK_HIP(hipStreamSynchronize(runtime.stream()));
+```
+
+该 kernel 对相同最大值选择更小 token id，适合作为确定性 greedy 基准。`temperature == 0` 不执行除零或 softmax。
+
+以下情况仍走 CPU sampler：
+
+- `temperature > 0` 时的随机采样，可再组合 top-k/top-p；
+- `repetition_penalty != 1.0`，但尚未实现 GPU logit processor；
+- 需要保存/检查完整 logits 的 correctness 调试。
+
+CPU 路径显式使用 runtime 的 stream，不能引用一个未声明的局部 `stream`：
+
+```cpp
+CHECK_HIP(hipMemcpyAsync(
+        h_logits.data(),
+        runtime.device_logits(),
+        vocab_size * sizeof(float),
+        hipMemcpyDeviceToHost,
+        runtime.stream()));
+CHECK_HIP(hipStreamSynchronize(runtime.stream()));
+int32_t next_token = sample_logits(h_logits, params, generated_tokens);
+```
+
+Qwen3 vocab 是 151936，完整复制每步为：
+
+```text
+151936 * sizeof(float) = 607744 bytes ~= 0.58 MiB
+```
+
+Sampler 只读取 logits 和生成历史，不修改 KV cache、`current_pos`、`n_prompt` 或 `has_logits`。GPU greedy 是一个外部采样算子，不改变“Runtime 只负责 forward”的边界。
+
+Stop token 的第一来源是已经加载的 tokenizer：
+
+```cpp
+std::vector<int32_t> effective_stop_ids;
+if (tokenizer.eos_token_id() >= 0) {
+    effective_stop_ids.push_back(tokenizer.eos_token_id());
+}
+for (int32_t id : sparams.stop_token_ids) {
+    append_unique(effective_stop_ids, id);
+}
+```
+
+这份合并后的列表在生成循环中称为 `effective_stop_ids`。也可以从 HTTP/生成参数附加明确的 stop token id。不要要求 GGUF 一定存在 `tokenizer.ggml.eot_token_id`；当前 `Qwen3TokenizerData` 没有这个必需字段。
+
+遇到 stop token 时不要把特殊 token 文本输出给用户：
+
+```cpp
+if (contains(effective_stop_ids, next_token)) {
+    finish_reason = "stop";
+    break;
+}
+```
+
+## 14. Tokenizer 和 Detokenizer
+
+Tokenizer 已由本目录的 `tokenizer.hpp` / `tokenizer.cpp` 实现，是 CPU 侧 `Qwen3Engine` 功能，不属于 GPU forward。GGUF loader 构造：
+
+```text
+tokenizer.ggml.model
+tokenizer.ggml.pre
+tokenizer.ggml.tokens
+tokenizer.ggml.merges
+tokenizer.ggml.token_type
+tokenizer.ggml.bos_token_id
+tokenizer.ggml.eos_token_id
+tokenizer.ggml.padding_token_id
+tokenizer.ggml.add_bos_token
+```
+
+并交给当前真实接口：
+
+```cpp
+Qwen3TokenizerData tokenizer_data = load_tokenizer_metadata(...);
+Qwen3Tokenizer tokenizer;
+std::string error;
+if (!tokenizer.load(tokenizer_data, &error)) {
+    throw std::runtime_error(error);
+}
+```
+
+普通文本编码：
+
+```cpp
+Qwen3EncodeOptions options;
+options.parse_special = true;
+options.add_bos = false; // Qwen3 normally has no BOS
+options.add_eos = false;
+
+std::vector<int32_t> prompt_ids = tokenizer.encode(prompt, options);
+```
+
+单轮 chat：
+
+```cpp
+std::string formatted = tokenizer.format_chat_prompt(
+        user_text,
+        system_text,
+        /* enable_thinking = */ false);
+std::vector<int32_t> prompt_ids = tokenizer.encode(formatted, options);
+```
+
+流水线 C 的输出上限较短，因此 HTTP 首版默认 `enable_thinking=false`，避免 thinking 内容占满 `max_tokens` 后还没有产生最终答案。Tokenizer 当前只承诺最小单轮 `system + user` chat，不要伪装成完整多轮模板兼容。
+
+Detokenizer 直接对已生成的 token id 序列调用：
+
+```cpp
+std::string text = tokenizer.decode(generated_ids, /* skip_special = */ true);
+```
+
+底层数值测试应绕过 tokenizer，直接传固定 `int32_t` token ids；HTTP/端到端测试才使用 chat template 和 decode。这样能把 tokenizer 错误与模型 forward 错误分开。
+
+## 15. Generate Loop 伪代码
+
+```cpp
+std::string formatted = tokenizer.format_chat_prompt(
+        user_text, system_text, /* enable_thinking = */ false);
+
+Qwen3EncodeOptions encode_options;
+encode_options.parse_special = true;
+encode_options.add_bos = false;
+encode_options.add_eos = false;
+
+std::vector<int32_t> prompt_ids = tokenizer.encode(formatted, encode_options);
+
+// sampler is an already initialized Qwen3Engine member.
+runtime.reset();
+CHECK_RUNTIME(runtime.prefill(
+        prompt_ids.data(), prompt_ids.size(), &error));
+
+std::vector<int32_t> effective_stop_ids = sparams.stop_token_ids;
+if (tokenizer.eos_token_id() >= 0) {
+    append_unique(effective_stop_ids, tokenizer.eos_token_id());
+}
+
+// Keep prompt + generated tokens inside the configured context contract.
+const int32_t available_new_tokens =
+        runtime.max_seq_len() - runtime.current_pos();
+const int32_t effective_max_new_tokens = std::max<int32_t>(
+        0,
+        std::min(sparams.max_new_tokens, available_new_tokens));
+
+std::vector<int32_t> generated_ids;
+generated_ids.reserve(effective_max_new_tokens);
+std::string finish_reason = "length";
+
+for (int32_t generated = 0;
+     generated < effective_max_new_tokens;
+     ++generated) {
+    int32_t next = -1;
+    CHECK_SAMPLER(sampler.sample(
+            runtime, sparams, generated_ids, &next, &error));
+
+    if (contains(effective_stop_ids, next)) {
+        finish_reason = "stop";
+        break;
+    }
+
+    generated_ids.push_back(next);
+
+    // The sampled token already counts as one generated token. Do not run
+    // another decode when this was the requested final token.
+    if (generated + 1 == effective_max_new_tokens) {
+        break;
+    }
+
+    // Capacity was clamped before the loop; decode(next) writes current_pos.
+    CHECK_RUNTIME(runtime.decode(next, &error));
+}
+
+std::string output = tokenizer.decode(
+        generated_ids, /* skip_special = */ true);
+```
+
+这个循环最多产生 `min(max_new_tokens, max_seq_len - prompt_tokens)` 个 token，不是 `max_new_tokens + 1`。在进入循环前收紧上限，可以避免“最后一次 decode 已填满 context，下一轮仍从 logits 多采一个 token”的 off-by-one。若 `effective_max_new_tokens == 0`，直接以 `finish_reason="length"` 返回。`prefill()` 和 `decode()` 都只更新 logits；采样、stop 判断和 detokenize 在外层完成。
+
+## 16. Chunked Prefill
+
+第一版可以限制：
+
+```cpp
+prompt_ids.size() <= max_prefill_tokens
+```
+
+后面支持长 prompt 时做 chunked prefill：
+
+```cpp
+start_pos = 0;
+while (start_pos < prompt_len) {
+    chunk = prompt_ids[start_pos : start_pos + chunk_size]
+    const bool is_last = start_pos + chunk.size() == prompt_len
+    forward_tokens(
+        chunk,
+        start_pos,
+        produce_logits=is_last)
+    start_pos += chunk.size()
+}
+```
+
+每个 chunk 都从该 chunk 自己的 embedding 开始，并完整执行全部 36 层。每一层都读取该层已有的历史 KV，并写入当前 chunk 的 KV。跨 chunk 保留的是每层 KV cache，不是上一个 chunk 的 residual/hidden。
+
+前面的 chunk 可以跳过 final norm 和 LM Head；最后一个 chunk 才产生最终 logits。非末 chunk 完成全部 36 层并通过 stream 错误检查后即可提交 `current_pos`；最后一个 chunk 还必须成功完成 final norm 和 LM Head 才能提交。公开 `prefill()` 只有在最后一个 chunk 成功后才设置 `n_prompt=prompt_len` 和 `has_logits=true`。
+
+chunked prefill 的 attention 要能看见历史 cache：
+
+```text
+chunk token at local t attends positions 0 ... start_pos + t
+```
+
+当前 `prefill_gqa_attention_kernel` 有 `start_pos` 参数，可以按这个方向接。
+
+第一版在 chunked prefill 完成之前，可以明确拒绝：
+
+```cpp
+prompt_ids.size() > max_prefill_tokens
+```
+
+不能静默截断 prompt。
+
+## 17. Error Handling
+
+每个 HIP/hipBLAS 调用后检查返回值：
+
+```cpp
+#define CHECK_HIP(x) ...
+#define CHECK_HIPBLAS(x) ...
+```
+
+Runtime 初始化时检查：
+
+```cpp
+dim % n_head == 0
+head_dim == dim / n_head
+n_head % n_kv_head == 0
+max_seq_len > 0
+max_prefill_tokens > 0
+all required tensors exist
+norm tensors exposed as float*
+matrix tensors have expected shape
+```
+
+初始化和请求生命周期必须显式检查：
+
+```text
+initialize may run once
+initialize success -> initialized=true, valid=true, has_logits=false
+prefill requires initialized && valid && current_pos==0 && n_prompt==0
+prefill success -> n_prompt=total prompt length && has_logits=true
+decode requires initialized && valid && has_logits && current_pos>0
+reset requires initialized and clears current_pos/n_prompt/has_logits
+device_logits/sampler requires has_logits==true
+```
+
+每轮生成检查：
+
+```cpp
+token_id >= 0 && token_id < vocab_size
+start_pos >= 0
+n_tokens > 0
+n_tokens <= max_prefill_tokens for one chunk
+start_pos + n_tokens <= max_seq_len
+start_pos + n_tokens <= rope_table_positions
+state.valid == true
+logits has no NaN/Inf, optional debug
+```
+
+边界检查必须在启动第一个 kernel 之前完成。当前 RoPE/KV kernel 的部分越界路径会直接 return，launch 本身仍可能返回成功；如果只在调用后看 `hipGetLastError()`，会得到“成功但 cache 没写完整”的状态。
+
+错误处理采用提交语义：
+
+```text
+old_pos = state.current_pos
+state.has_logits = false
+run all kernels for this forward
+check wrapper status
+hipStreamSynchronize(stream) once at the forward boundary
+
+success -> state.current_pos = old_pos + n_tokens; state.has_logits = produce_logits
+failure -> state.current_pos = old_pos; state.valid = false; state.has_logits = false
+```
+
+首版为了可靠提交状态，在一次完整 prefill/decode 的末尾同步当前 stream 一次，而不是每层同步。这样可以在递增 `current_pos` 前捕获异步 HIP 错误；后续若做全异步 runtime，再用 event/future 表达提交完成。
+
+`state.valid=false` 后，除 `reset()` 和析构外的 forward 都应拒绝执行。错误日志至少包含 `layer/op/M/N/K/start_pos/n_tokens`，方便区分 loader、GEMM、attention 和 cache 错误。
+
+## 18. 最小实现顺序
+
+建议按这个顺序做：
+
+1. 写 `Qwen3Runtime` 类，只支持手写 token ids，不接 tokenizer。
+2. 以非拥有引用从 `Qwen3GgufModel` 拿固定 config 和 weight pointers。
+3. 分配 activation buffers、KV cache、RoPE table。
+4. 实现 `prefill(prompt_ids)`，只支持 prompt 长度不超过 `max_prefill_tokens`。
+5. 调用现有 `qwen3_z200_launch_greedy_sample()`，只回传一个 token id，实现确定性 GPU greedy。
+6. 实现 `decode(token_id)` 单步循环。
+7. 用固定 token ids 做 logits/KV 数值验证。
+8. 接现有 `Qwen3Tokenizer` 和单轮 chat template。
+9. 为 top-k/top-p、temperature、repetition penalty 和调试接完整 logits 的 CPU sampler。
+10. 接 `07_qwen3_http_server_contract.md` 的 C++ HTTP server。
+11. 再考虑 chunked prefill、GPU logit processors、FP16 KV、paged KV、性能优化。
+
+## 19. 固定生成状态机
+
+实现 Agent 不需要读取或复制 llama.cpp、vLLM 等现有推理框架。当前任务的最小状态机已经完全定义为：
+
+```text
+load_qwen3_gguf
+Qwen3Tokenizer::load
+Qwen3Runtime(model-reference)
+runtime.initialize
+
+per request:
+  format chat prompt
+  tokenizer.encode
+  runtime.reset
+  runtime.prefill(prompt_ids) -> logits
+
+loop:
+  next_token = external sampler
+    greedy: GPU argmax -> copy one int32
+    other policies/debug: copy full logits -> CPU sampler
+  stop check
+  append generated id
+  if max/context limit: break
+  runtime.decode(next_token) -> next logits
+
+tokenizer.decode(all generated ids)
+```
+
+关键规则：
+
+- prompt 先整体 prefill。
+- 生成阶段每轮只 decode 一个新 token。
+- sampler 在 logits 后面，不在 Transformer block 里面。
+- detokenizer 在 CPU 侧，并对生成 id 序列调用当前 `decode()` 接口。
+- 每轮都要检查 context/KV cache 容量。
+- EOG/EOS token 要能停止生成。
+
+本项目明确不引入：
+
+- 不要用 `llama_context`。
+- 不要用 `llama_batch` 数据结构，除非你想做兼容层。
+- 不要 build GGML graph。
+- 不要接 `ggml_backend_sched_graph_compute_async`。
+- 不要引入 llama.cpp 的全套 backend/device/buffer 抽象。
+
+当前 runtime 要显式做 llama.cpp 在 `llama_decode()` 里面隐藏起来的事情：
+
+```text
+embedding
+per-layer attention/ffn forward
+KV cache write/read
+lm_head
+logits
+```
+
+## 20. 不使用 GGML 时的责任拆分
+
+这里不 build 通用计算图，也不接 backend scheduler。`Qwen3Runtime` 显式调用：
+
+```text
+rms_norm
+linear
+q/k norm
+rope
+kv write
+attention
+linear
+add
+ffn
+lm_head
+```
+
+Runtime 输出 logits 后返回。上层 `Qwen3Engine` 再负责 sampler、stop token、detokenizer 和 HTTP response。不要在 Transformer block 内部采样，也不要让 HTTP 层直接修改 `current_pos` 或 KV cache。
+
+好处是简单直接，适合固定 Qwen3-8B + Z200 bring-up。
+
+坏处是：
+
+- 不通用。
+- 手动管理 buffer。
+- 手动处理 shape 和 dtype。
+- 性能优化要自己做。
+
+## 21. 验收标准
+
+第一版 runtime 的结构验收应满足：
+
+```text
+1. 输入一串 token ids。
+2. prefill 能跑完所有 36 层。
+3. 每层 KV cache 写入位置正确。
+4. lm_head 得到 [vocab_size] logits。
+5. Runtime 只输出 logits；外部 GPU greedy sampler 返回合法 token id，CPU sampler 可作为复杂策略/调试回退。
+6. decode 可以连续跑多步，current_pos 正确递增。
+7. 遇到 EOS、配置的 stop token 或 max_new_tokens 停止。
+8. 不依赖 GGML tensor、GGML graph、GGML backend。
+```
+
+仅仅“能跑出 token”不算数值正确。必须增加以下 golden tests：
+
+1. **固定 token ids 的 logits 对齐**：绕过 tokenizer，使用同一个 Q8_0 GGUF，比较最后一行 logits。记录最大绝对/相对误差，并比较 top-1；不要对浮点结果使用 `memcmp`。
+2. **Prefill/Decode 等价性**：对 token 序列 `[t0..tN]`，比较一次完整 prefill 的最后 logits，与 `prefill(t0) + decode(t1)..decode(tN)` 的最后 logits。
+3. **Chunk 等价性**：实现 chunked prefill 后，比较完整 prefill 与不同 chunk size 的最后 logits。
+4. **KV 位置测试**：用递增小张量检查每层 K/V 的 `start_pos + local_t` 索引，确认 GQA 只分配 8 个 KV heads。
+5. **Tokenizer 独立测试**：encode/decode/chat template 单独测试，不用生成 token 是否“看起来合理”替代 tokenizer golden。
+6. **Sampler 独立测试**：构造已知 device logits，验证 GPU greedy 的 argmax、相同最大值取较小 id、只回传一个 `int32_t`，并验证 EOS/配置 stop 合并和 `max_new_tokens`/context 计数。
+
+调试时先打印：
+
+```text
+prompt ids
+current_pos before/after prefill
+next token id
+current_pos before/after each decode
+first few logits
+whether any buffer has NaN
+```
+
+端到端比较时必须使用同一份 Q8_0 GGUF、完全相同的 token ids 和 greedy 参数。先比较 logits/top-1，再比较生成 token；不要只用“同一句 prompt”，因为 chat template、thinking mode 或 BOS 差异会改变实际输入 token。
+
+HTTP 层的额外验收见 `07_qwen3_http_server_contract.md`。

--- a/metainfer/tasks/gen_cpp_infer_framework/notebooks/07_qwen3_http_server_contract.md
+++ b/metainfer/tasks/gen_cpp_infer_framework/notebooks/07_qwen3_http_server_contract.md
@@ -1,0 +1,641 @@
+# Qwen3-8B C++ HTTP Server 与 `serve.sh` 契约
+
+> 用途：给实现 Agent 一份可以直接接入 MetaInfer 流水线 C 的服务层契约。本文只负责把已经完成的 Qwen3 tokenizer、runtime 和 sampler 暴露成 HTTP API，不改变模型计算。
+
+## 1. 最终目标
+
+生成目录中必须提供：
+
+```text
+CMakeLists.txt
+build.sh                         # 流水线生成并拥有，不得修改
+serve.sh                         # Agent 编写，前台启动服务
+include/http_server.hpp
+include/openai_api.hpp
+src/main.cpp
+src/http_server.cpp
+src/openai_api.cpp
+src/engine.cpp
+src/model_loader.cpp
+src/tokenizer.cpp
+src/sampler.cpp
+...
+```
+
+构建后必须产生：
+
+```text
+build/metainfer_cpp_server
+```
+
+流水线 C 不会直接调用 C++ 类。它只通过 `serve.sh` 启动程序，再通过 HTTP 检查框架。
+
+```text
+MetaInfer C oracle
+  -> bash build.sh
+  -> MODEL_DIR=<real-model> bash serve.sh <free-port>
+       -> exec build/metainfer_cpp_server --port <port> --model <real-model>
+            -> load GGUF + tokenizer + Qwen3Runtime
+            -> GET  /v1/models
+            -> POST /v1/chat/completions
+  -> extract choices[0].message.content
+  -> judge responses
+  -> SIGTERM server process group
+```
+
+当前流水线契约的源码参考路径：
+
+```text
+metainfer/tasks/gen_cpp_infer_framework/orchestrator/prompts.py
+metainfer/tasks/gen_cpp_infer_framework/orchestrator/oracles/correctness.py
+metainfer/tasks/gen_cpp_infer_framework/orchestrator/oracles/perf.py
+```
+
+## 2. 流水线 C 的真实启动过程
+
+流水线按以下顺序执行：
+
+1. 检查 `build.sh` 和 `serve.sh` 存在。
+2. 执行系统生成的 `bash build.sh`。
+3. 检查构建是否成功；失败时不会启动服务器。
+4. 选择一个空闲的 localhost TCP 端口。
+5. 设置真实模型路径：
+
+   ```bash
+   export MODEL_DIR=/path/to/model
+   ```
+
+6. 执行：
+
+   ```bash
+   bash serve.sh <port>
+   ```
+
+7. 轮询 `GET /v1/models`；模型未就绪时允许暂时连接失败或返回 `503`。
+8. 服务就绪后，逐个发送 `POST /v1/chat/completions`。
+9. 从响应的 `choices[0].message.content` 取出模型文本。
+10. 测试结束后向整个服务进程组发送 `SIGTERM`，超时才使用 `SIGKILL`。
+
+因此 `serve.sh` 必须阻塞在前台，不能 daemonize，不能使用 `&` 启动后立即退出。
+
+## 3. 服务层和模型层的边界
+
+C++ HTTP 层只做：
+
+- TCP/HTTP 请求接收；
+- JSON 解析与校验；
+- OpenAI 请求转换为内部 `GenerateRequest`；
+- 调用 tokenizer、runtime 和 sampler；
+- 把生成文本封装成 JSON；
+- 错误码、信号和资源生命周期管理。
+
+HTTP 层不要重新实现：
+
+- GGUF tensor 解析；
+- Q8_0 反量化；
+- Transformer forward；
+- KV cache 算法；
+- HIP kernel。
+
+建议内部接口：
+
+```cpp
+struct GenerateRequest {
+    std::string system_text;
+    std::string user_text;
+    int32_t max_new_tokens = 128;
+    float temperature = 0.0f;
+    uint64_t seed = 0;
+    bool enable_thinking = false;
+};
+
+struct GenerateResult {
+    std::string text;
+    int32_t prompt_tokens = 0;
+    int32_t completion_tokens = 0;
+    bool stopped_by_eos = false;
+};
+
+class Qwen3Engine {
+public:
+    bool initialize(const std::string& model_path, std::string* error);
+    bool generate(
+            const GenerateRequest& request,
+            GenerateResult* result,
+            std::string* error);
+};
+```
+
+`Qwen3Engine` 初始化一次并长期持有模型权重。每个请求重新设置生成状态和 KV cache 位置，但不能重新加载权重。
+
+## 4. C++ 主程序参数
+
+建议二进制支持：
+
+```text
+metainfer_cpp_server \
+  --host 127.0.0.1 \
+  --port 18080 \
+  --model /path/to/Qwen3-8B-Q8_0.gguf
+```
+
+至少支持：
+
+```text
+--host <ip>       default: 127.0.0.1
+--port <1..65535> required
+--model <path>    required after fallback resolution
+--help
+--version
+```
+
+模型参数可以是 GGUF 文件，也可以是模型目录。若是目录，必须使用确定性的规则选择模型：
+
+1. 优先寻找任务配置指定的 GGUF 文件名；
+2. 否则目录中必须恰好只有一个 `.gguf`；
+3. 存在零个或多个候选时打印清晰错误并退出，不能随便选第一个文件。
+
+启动顺序建议：
+
+```text
+parse args
+validate model path
+create/load Qwen3GgufModel
+create tokenizer
+create Qwen3Runtime and allocate GPU buffers
+create sampler
+bind/listen HTTP socket
+enter blocking accept loop
+```
+
+首版可以同步加载完模型后再监听端口。流水线允许加载期间连接失败，并会等待最多数分钟。这样比“先监听、后台加载、管理 ready 状态”更简单。
+
+## 5. 必须实现的 HTTP 路由
+
+### 5.1 `GET /v1/models`
+
+模型加载完成后返回 `200 application/json`：
+
+```json
+{
+  "object": "list",
+  "data": [
+    {
+      "id": "qwen3-8b",
+      "object": "model",
+      "created": 0,
+      "owned_by": "metainfer"
+    }
+  ]
+}
+```
+
+流水线把这个接口当成低开销 readiness 检查。不要在这个请求中执行一次模型生成。
+
+### 5.2 `POST /v1/chat/completions`
+
+这是流水线 C 真正使用的接口。实际请求形状为：
+
+```json
+{
+  "model": "default",
+  "messages": [
+    {"role": "user", "content": "What is the capital of France?"}
+  ],
+  "max_tokens": 16,
+  "temperature": 0.0,
+  "stream": false
+}
+```
+
+健康探测可能把 `model` 写成 `probe`，正式测试通常写成 `default`。固定 Qwen3-8B 服务应接受这两个别名，不能因为它们和 `qwen3-8b` 不同而拒绝请求。
+
+首版必须解析：
+
+- `messages[].role`；
+- `messages[].content`；
+- `max_tokens`；
+- `temperature`；
+- `stream`；
+- 可选 `seed`。
+
+流水线只发送 `stream: false`。首版遇到 `stream: true` 可以返回 `400`，但不能返回伪造的非流式结果并声称是 SSE。
+
+最小成功响应：
+
+```json
+{
+  "id": "chatcmpl-metainfer-1",
+  "object": "chat.completion",
+  "created": 0,
+  "model": "qwen3-8b",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "Paris"
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 12,
+    "completion_tokens": 1,
+    "total_tokens": 13
+  }
+}
+```
+
+流水线判定成功的关键字段是：
+
+```text
+choices[0].message.content
+```
+
+它必须存在且必须是 JSON string。HTTP `200` 但 `choices` 为空，仍然会被判为无输出。
+
+`finish_reason` 建议：
+
+```text
+stop    -> EOS/EOG/stop token
+length  -> 达到 max_tokens 或上下文容量
+```
+
+### 5.3 `POST /v1/completions`
+
+流水线 C 当前不依赖它，可以第二阶段再实现。若实现，返回：
+
+```json
+{
+  "choices": [
+    {"index": 0, "text": "...", "finish_reason": "stop"}
+  ]
+}
+```
+
+## 6. Chat 请求到 Qwen3 Runtime 的调用流程
+
+单个流水线请求应执行：
+
+```text
+parse JSON
+  -> extract optional system message and user message
+  -> Qwen3Tokenizer::format_chat_prompt(user, system, enable_thinking=false)
+  -> tokenizer.encode(prompt, parse_special=true, add_bos=false)
+  -> runtime.reset()
+  -> runtime.prefill(prompt_token_ids)
+  -> sample logits
+  -> repeat runtime.decode(previous_token)
+  -> stop on EOS/EOG, max_tokens, or context capacity
+  -> tokenizer.decode(generated_ids, skip_special=true)
+  -> OpenAI JSON response
+```
+
+流水线的测试输出上限较短。为避免 Qwen3 thinking 内容耗尽 `max_tokens` 后还没有给出最终答案，首版服务建议默认：
+
+```cpp
+enable_thinking = false;
+```
+
+如果后面需要 thinking mode，可以增加非标准可选字段或启动参数，但不能改变流水线默认行为。
+
+首版 tokenizer 只完整支持单轮 `system + user`。若收到超出当前能力的多轮 `assistant/user` 历史，应返回清晰 `400`；不要错误地把所有 role 文本直接拼接成普通字符串。
+
+## 7. 单卡 Runtime 的并发规则（B=1 基线）
+
+当前 `Qwen3Runtime` 只有一套：
+
+- `current_pos`；
+- KV cache；
+- activation workspace；
+- FP16 权重反量化 workspace；
+- hipBLAS handle 和 HIP stream。
+
+这些状态不能被两个请求同时使用。
+
+首版最安全的实现是整个服务串行处理请求：
+
+```cpp
+accept connection
+read request
+handle complete generation
+write response
+close connection
+```
+
+也可以让 HTTP 层使用工作线程，但调用 `engine.generate()` 时必须持有覆盖完整生成周期的全局 mutex：
+
+```cpp
+std::lock_guard<std::mutex> lock(engine_mutex);
+engine.generate(...);
+```
+
+不能只锁单个 decode step，否则请求 A/B 会交替覆盖同一套 KV cache。
+
+流水线 C 顺序发送请求，因此串行首版可以通过正确性测试。性能流水线 E 会并发发送请求；串行服务仍能工作，但吞吐较低。
+
+> **continuous batching 实现时，以上“全程 engine mutex”模式不再适用。** 必须以 `09_continuous_batching_contract.md` 为唯一并发规范：HTTP worker 只向有界队列提交请求；一个可 join 的 scheduler 线程独占 runtime/HIP stream；每请求独占 KV slot；scheduler 每个 decode tick 动态合并活跃 slot。不要仅删除 mutex，也不要让多个 HTTP worker 直接调用 runtime。
+
+## 8. 最小 HTTP/1.1 传输契约
+
+可以使用系统已有的 HTTP/JSON 库，也可以编写一个小型 POSIX socket server。禁止运行时下载依赖。
+
+若自己实现，至少保证：
+
+1. 使用 `socket`、`bind`、`listen`、`accept`。
+2. 设置 `SO_REUSEADDR`。
+3. 读取到 `\r\n\r\n` 后再解析 header。
+4. header 名大小写不敏感。
+5. 根据 `Content-Length` 循环读取完整 body，不能假设一次 `recv()` 就收到完整 JSON。
+6. 设置 header/body 大小上限，例如 64 KiB/1 MiB，超限返回 `413`。
+7. 首版可以只支持 `Content-Length`，不支持 chunked request 时返回 `400` 或 `501`。
+8. 响应必须包含：
+
+   ```text
+   HTTP/1.1 200 OK
+   Content-Type: application/json; charset=utf-8
+   Content-Length: <exact byte count>
+   Connection: close
+   ```
+
+9. 循环 `send()`，直到完整响应发送完或连接失败。
+10. 每个连接处理一个请求后关闭；首版不必实现 keep-alive。
+
+JSON parser 至少要正确处理 object、array、string、number、boolean、null，以及字符串中的：
+
+```text
+\"  \\  \n  \r  \t  \uXXXX
+```
+
+JSON serializer 必须转义模型输出中的双引号、反斜杠和控制字符。不能直接用字符串拼接把原始模型文本塞进 JSON，否则代码输出中的 `"` 或换行会产生非法响应。
+
+## 9. 参数校验和 HTTP 错误
+
+建议返回统一错误结构：
+
+```json
+{
+  "error": {
+    "message": "messages must contain one user message",
+    "type": "invalid_request_error",
+    "code": "invalid_messages"
+  }
+}
+```
+
+状态码建议：
+
+| 情况 | 状态码 |
+| --- | ---: |
+| 非法 JSON、字段类型错误 | 400 |
+| 不支持 `stream:true` | 400 |
+| 未知路由 | 404 |
+| 路由存在但方法错误 | 405 |
+| body 过大 | 413 |
+| 模型仍在加载 | 503 |
+| HIP/hipBLAS/生成失败 | 500 |
+
+输入限制至少包括：
+
+```cpp
+1 <= max_tokens && max_tokens <= runtime_limit
+temperature >= 0.0f
+messages is a non-empty array
+content is a string
+prompt_tokens + max_tokens <= max_seq_len
+```
+
+上下文超过容量时可以减少实际生成上限并用 `finish_reason="length"`，也可以返回 `400`；必须避免 KV cache 越界。
+
+## 10. `serve.sh` 契约与模板
+
+`serve.sh` 的模型路径解析顺序必须是：
+
+1. 第二个位置参数 `$2`；
+2. 环境变量 `$MODEL_DIR`；
+3. 从任务 requirements 写入的固定默认路径。
+
+不能在真实模型缺失时静默切换成 mock、echo 或随机输出。
+
+参考模板：
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+PORT="${1:-}"
+DEFAULT_MODEL_PATH="/absolute/path/from/task-requirements"
+MODEL_PATH="${2:-${MODEL_DIR:-${DEFAULT_MODEL_PATH}}}"
+
+if [[ -z "${PORT}" || ! "${PORT}" =~ ^[0-9]+$ ]] ||
+   (( PORT < 1 || PORT > 65535 )); then
+    echo "usage: $0 <port> [model-path]" >&2
+    exit 2
+fi
+
+if [[ -z "${MODEL_PATH}" || ! -e "${MODEL_PATH}" ]]; then
+    echo "model path does not exist: ${MODEL_PATH}" >&2
+    exit 3
+fi
+
+SERVER="${ROOT_DIR}/build/metainfer_cpp_server"
+if [[ ! -x "${SERVER}" ]]; then
+    bash "${ROOT_DIR}/build.sh"
+fi
+
+exec "${SERVER}" \
+    --host 127.0.0.1 \
+    --port "${PORT}" \
+    --model "${MODEL_PATH}"
+```
+
+关键点：
+
+- 使用 `exec`，让 C++ 进程继承 `serve.sh` 的 PID 和信号；
+- 不使用 `nohup`、`setsid` 或末尾 `&`；
+- 不吞掉 stdout/stderr，流水线会保存日志；
+- 不覆盖 `ROCR_VISIBLE_DEVICES`、`HIP_VISIBLE_DEVICES` 等硬件绑定环境变量；
+- 文件需要提交可执行权限：`chmod +x serve.sh`。
+
+## 11. SIGTERM 和资源清理
+
+流水线完成测试后会终止服务。服务器必须在大约十秒内退出。
+
+信号 handler 只能执行最小操作：
+
+```cpp
+volatile std::sig_atomic_t g_stop = 0;
+
+void on_signal(int) {
+    g_stop = 1;
+}
+```
+
+accept loop 可以使用 `poll/select` 的短超时定期检查 `g_stop`，或者使用 self-pipe 唤醒。不要在 signal handler 里调用 `hipFree`、C++ iostream、mutex 或复杂析构逻辑。
+
+### 11.1 禁止停止状态脱节（2026-07-20 回归记录）
+
+曾出现过如下实现：signal handler 只设置全局 `g_stop`，而 HTTP accept loop 检查的是 `SimpleHttpServer::stop_`。两者没有任何同步路径，因此 SIGTERM 虽然被捕获，服务却永远不会退出，smoke test 最终阻塞在 `wait`，同时长期占用端口和 GPU 显存。
+
+禁止这种“双停止变量”实现：
+
+```cpp
+volatile std::sig_atomic_t g_stop = 0;
+void on_signal(int) { g_stop = 1; }
+
+// BUG: loop 从不读取 g_stop，且没有代码调用 server.stop()。
+while (!stop_) {
+    accept(listen_fd, nullptr, nullptr);
+}
+```
+
+停止状态必须只有一条可证明的传播链。推荐使用以下任一方案：
+
+1. `poll/select` 或 self-pipe：signal handler 只设置 `g_stop` 并写入 self-pipe；accept loop 被唤醒后直接读取同一个 `g_stop`。
+2. 专用 `sigwait` 线程：主线程先 block SIGTERM/SIGINT，等待线程通过 `sigwait` 收到信号后调用 `server.stop()`；`stop()` 设置 `std::atomic<bool>` 并 `shutdown()` 监听 socket，以解除阻塞的 `accept()`。复杂 C++ 清理由正常控制流执行，不在 signal handler 内执行。
+
+无论采用哪种方案，都必须满足：
+
+- `accept()` 返回错误后先检查停止状态；已停止时立即 `break`，不得重试；
+- 不依赖 `SO_RCVTIMEO` 自动解决 shutdown；必须显式证明 loop 会观察到停止状态；
+- SIGTERM 后十秒内进程退出 0 或约定的受控退出码；
+- 析构顺序释放 socket、scheduler/worker、HIP stream/handle、KV cache 与模型权重；
+- Continuous batching 模式还必须唤醒 condition variable、完成或取消 pending/active 请求，并 join scheduler，不能留下 detached thread。
+
+Smoke test 必须同时验证“请求成功”和“能够退出”：
+
+```bash
+bash serve.sh "${PORT}" >server.stdout.log 2>server.stderr.log &
+server_pid=$!
+
+# health / generation checks ...
+
+kill -TERM "${server_pid}"
+for _ in $(seq 1 100); do
+    kill -0 "${server_pid}" 2>/dev/null || break
+    sleep 0.1
+done
+if kill -0 "${server_pid}" 2>/dev/null; then
+    kill -KILL "${server_pid}"
+    wait "${server_pid}" || true
+    echo "server ignored SIGTERM" >&2
+    exit 1
+fi
+wait "${server_pid}"
+```
+
+进程检查不得使用裸 `pgrep -f metainfer_cpp_server` 作为成功判据；`-f` 会匹配检查命令自身或包含该字符串的父 shell，产生看似“不断重生 PID”的假阳性。优先保存并检查 `$!`，需要扫描时使用精确的 `/proc/<pid>/exe`、`ps` 字段或排除检查进程本身。测试应杀 `serve.sh` 通过 `exec` 暴露的真实 server PID；若引入 `timeout`/wrapper，则必须明确杀整个测试进程组，并在 TERM 宽限期后升级到 KILL。
+
+退出 accept loop 后再按正常 C++ 生命周期：
+
+```text
+stop accepting requests
+finish or abort active request
+destroy HTTP resources
+destroy Qwen3Runtime buffers/KV cache
+destroy hipBLAS handle and HIP stream
+free model device weights
+exit 0
+```
+
+## 12. CMake 和 `build.sh`
+
+Agent 只维护 `CMakeLists.txt`；`build.sh` 由流水线和硬件 profile 生成，不得修改。
+
+`CMakeLists.txt` 必须定义准确目标名：
+
+```cmake
+add_executable(metainfer_cpp_server
+    src/main.cpp
+    src/http_server.cpp
+    src/openai_api.cpp
+    src/engine.cpp
+    src/model_loader.cpp
+    src/tokenizer.cpp
+    src/sampler.cpp
+    # HIP sources...
+)
+```
+
+要求：
+
+- C++17 或更高；
+- include path 指向项目 `include/`；
+- 链接 HIP runtime、hipBLAS 和必要的线程库；
+- 不使用 `FetchContent`、`git clone` 或运行时下载；
+- `bash build.sh` 成功后，`./build/metainfer_cpp_server --help` 必须返回 0。
+
+## 13. 本地 Smoke Test
+
+交给流水线 C 前至少完成：
+
+```bash
+bash build.sh
+./build/metainfer_cpp_server --help
+```
+
+然后在一个空闲端口启动：
+
+```bash
+MODEL_DIR=/path/to/model bash serve.sh 18080 \
+    >server.stdout.log 2>server.stderr.log &
+SERVER_PID=$!
+```
+
+健康检查：
+
+```bash
+curl -fsS http://127.0.0.1:18080/v1/models
+```
+
+生成检查：
+
+```bash
+curl -fsS \
+  -H 'Content-Type: application/json' \
+  -d '{
+        "model":"default",
+        "messages":[{"role":"user","content":"What is the capital of France?"}],
+        "max_tokens":16,
+        "temperature":0,
+        "stream":false
+      }' \
+  http://127.0.0.1:18080/v1/chat/completions
+```
+
+响应需要能被标准 JSON parser 解析，并且：
+
+```text
+choices[0].message.content is a non-empty string
+```
+
+测试后：
+
+```bash
+kill -TERM "${SERVER_PID}"
+wait "${SERVER_PID}"
+```
+
+不要把后台测试进程留给下一次运行，否则可能占用端口和 Z200 显存。
+
+## 14. 首版验收清单
+
+- [ ] `bash build.sh` 产生 `build/metainfer_cpp_server`。
+- [ ] `--help` 和 `--version` 不加载模型并返回 0。
+- [ ] `serve.sh <port>` 前台阻塞，并使用 `exec` 启动 C++ server。
+- [ ] `$2 -> $MODEL_DIR -> 固定默认值` 的模型路径优先级正确。
+- [ ] 模型路径错误时打印真实路径并非零退出，不进入 mock 模式。
+- [ ] 模型和 GPU buffer 只在启动时加载/分配一次。
+- [ ] `GET /v1/models` 返回合法 JSON 和 HTTP 200。
+- [ ] `POST /v1/chat/completions` 接受 `model=probe/default`。
+- [ ] 支持 `stream:false`、`temperature:0` 和 `max_tokens`。
+- [ ] `choices[0].message.content` 是非空字符串。
+- [ ] 模型输出经过正确 JSON escaping。
+- [ ] B=1 基线中，每个请求开始前 reset runtime/KV 状态。
+- [ ] B=1 基线中，单卡串行执行完整请求，不交叉覆盖 KV cache；continuous batching 实现改按 `09_continuous_batching_contract.md` 的 slot/KV 隔离与并发验收执行。
+- [ ] EOS/EOG、`max_tokens` 和 context limit 都能停止生成。
+- [ ] SIGTERM 能让服务在十秒内退出并释放 GPU 资源；测试同时覆盖空闲 `accept()` 和请求执行/排队期间的 shutdown。
+- [ ] 停止状态只有一条可证明的传播链，不存在 handler 写 `g_stop`、loop 却只读另一个 `stop_` 的脱节实现。
+- [ ] 本地 smoke test 后没有残留进程；使用保存的真实 PID/进程组验证，不以裸 `pgrep -f` 结果作为判据。

--- a/metainfer/tasks/gen_cpp_infer_framework/notebooks/08_qwen3_z200_numeric_test_contract.md
+++ b/metainfer/tasks/gen_cpp_infer_framework/notebooks/08_qwen3_z200_numeric_test_contract.md
@@ -1,0 +1,932 @@
+# Qwen3-8B Z200 C0.1 快速算子数值测试契约
+
+> 用途：指导实现 Agent 为生成的 C++/HIP 框架增加一个不加载真实模型、只使用确定性小张量的快速数值测试程序，并指导 MetaInfer 的 C 阶段在编译成功后、启动 HTTP server 前执行它。
+>
+> 本文只定义 **C0.1 快速算子数值测试**。固定 GGUF logits golden、完整模型数值 reference 和 HTTP 语义测试不属于本文范围。
+>
+> 多 slot / continuous batching 的 KV 隔离、batched logits 与 HTTP 并发测试不属于 C0.1；这些实现和验收以 `09_continuous_batching_contract.md` 为准。
+
+参考路径：
+
+```text
+MetaInfer/metainfer/tasks/gen_cpp_infer_framework/notebooks/qwen3_z200_kernels.hip.cpp
+MetaInfer/metainfer/tasks/gen_cpp_infer_framework/notebooks/04_qwen3_z200_operator_contract.md
+MetaInfer/metainfer/tasks/gen_cpp_infer_framework/notebooks/06_qwen3_runtime_notes.md
+MetaInfer/metainfer/tasks/gen_cpp_infer_framework/notebooks/09_continuous_batching_contract.md
+MetaInfer/metainfer/tasks/gen_cpp_infer_framework/orchestrator/hardware.py
+MetaInfer/metainfer/tasks/gen_cpp_infer_framework/orchestrator/oracles/correctness.py
+MetaInfer/metainfer/tasks/gen_cpp_infer_framework/orchestrator/pipeline.py
+```
+
+## 1. C0.1 的目标和边界
+
+C0.1 要证明：生成框架实际链接的 Z200 HIP/hipBLAS 算子，在确定性小张量上与独立 CPU 公式一致。
+
+C0.1 必须满足：
+
+- 不加载 Qwen3-8B GGUF；
+- 不依赖 tokenizer、HTTP server 或 `serve.sh`；
+- 不分配完整模型权重和 KV cache；
+- 不访问网络、不下载 gtest 等依赖；
+- 使用固定输入、固定 seed、固定 shape；
+- 直接运行在目标 Z200/gfx906 上；
+- 与服务器链接同一个核心库和同一份 kernel object；
+- 全部通过时返回 `0`，任一失败时返回非零；
+- 正常目标是在几十秒内完成，C 阶段默认超时建议 120 秒。
+
+C0.1 能发现：
+
+- Q8_0 block layout、scale、行布局或 FP16 round 错误；
+- hipBLAS `M/N/K`、转置、leading dimension 错误；
+- RMSNorm reduction、Q/K per-head stride 错误；
+- Qwen3 NEOX RoPE 配对或 position 错误；
+- GQA 的 Q-head 到 KV-head 映射错误；
+- KV cache `start_pos + local_t` 写入错误；
+- prefill/decode attention 的 causal 范围或 softmax 错误；
+- SwiGLU、residual、greedy tie-break 和尾部元素错误。
+
+C0.1 不能单独证明：
+
+- GGUF metadata/tensor offset 加载正确；
+- 36 层完整 Qwen3-8B 的最终 logits 与可信 reference 一致；
+- tokenizer/chat template 正确；
+- HTTP JSON、`serve.sh` 和生成文本正确。
+
+因此完整 C 流程应是：
+
+```text
+B writes CMake + qwen3_core + qwen3_numeric_tests + server + serve.sh
+  -> C regenerates system-owned build.sh
+  -> C runs bash build.sh
+  -> C0.1 runs build/qwen3_numeric_tests
+       fail -> do not load model or start server
+       pass -> continue
+  -> C starts serve.sh with the real model
+  -> C runs existing OpenAI HTTP correctness cases
+```
+
+## 2. 生成框架必须提供的文件
+
+建议生成目录至少包含：
+
+```text
+CMakeLists.txt
+include/
+  qwen3_z200_kernels.h
+  qwen3_runtime.h
+src/
+  qwen3_z200_kernels.hip.cpp
+  qwen3_runtime.cpp
+  model_loader.cpp
+  engine.cpp
+  http_server.cpp
+tests/
+  qwen3_numeric_tests.cpp
+  cpu_reference.h
+  numeric_test_utils.h
+serve.sh
+build.sh                         # MetaInfer system-owned, Agent 不得修改
+```
+
+构建后必须存在：
+
+```text
+build/metainfer_cpp_server
+build/qwen3_numeric_tests
+```
+
+`qwen3_numeric_tests` 必须链接服务器使用的同一个 `qwen3_core`。禁止：
+
+- 在 `tests/` 再复制一份修改过的 kernel；
+- 测试直接编译 notebooks 里的参考源码，而服务器使用另一份生成源码；
+- 在测试中重写一个更简单的“假 GPU 实现”；
+- 只检查 wrapper 返回 success，不读取和比较输出；
+- 用当前 GPU 输出动态生成 expected value 再与自己比较。
+
+推荐 CMake 结构：
+
+```cmake
+add_library(qwen3_core STATIC
+    src/qwen3_z200_kernels.hip.cpp
+    src/qwen3_runtime.cpp
+    src/model_loader.cpp
+)
+
+# qwen3_core 在这里统一链接 HIP runtime/hipBLAS，并使用系统 build.sh
+# 注入的 gfx906、Release 和编译器设置。
+
+add_executable(metainfer_cpp_server
+    src/main.cpp
+    src/engine.cpp
+    src/http_server.cpp
+    src/openai_api.cpp
+)
+target_link_libraries(metainfer_cpp_server PRIVATE qwen3_core)
+
+add_executable(qwen3_numeric_tests
+    tests/qwen3_numeric_tests.cpp
+)
+target_link_libraries(qwen3_numeric_tests PRIVATE qwen3_core)
+
+enable_testing()
+add_test(NAME qwen3_numeric COMMAND qwen3_numeric_tests)
+```
+
+`qwen3_numeric_tests` 不能使用 `EXCLUDE_FROM_ALL`，因为 system-owned `build.sh` 只执行默认的：
+
+```bash
+cmake --build "$ROOT/build"
+```
+
+## 3. 测试程序 CLI 和返回契约
+
+最低要求：
+
+```bash
+./build/qwen3_numeric_tests
+```
+
+建议同时支持：
+
+```bash
+./build/qwen3_numeric_tests --list
+./build/qwen3_numeric_tests --filter q8_linear
+./build/qwen3_numeric_tests --report /path/to/numeric-test-report.json
+```
+
+返回码：
+
+| 返回码 | 含义 | C 阶段分类 |
+| ---: | --- | --- |
+| `0` | 所有数值测试通过 | 继续启动 server |
+| `1` | GPU 输出与 CPU reference 不一致 | `LOGIC_FAIL`，进入同迭代修复 |
+| `2` | CLI、缺少测试 binary、内部测试配置错误 | `LOGIC_FAIL`，生成物不满足契约 |
+| `3` | HIP device/stream/hipBLAS 初始化失败 | `INFRA_FAIL` |
+
+stdout 应保持可读：
+
+```text
+[PASS] cast_fp32_to_fp16       elements=257 exact=true
+[PASS] dequant_q8_0            elements=64 exact=true
+[PASS] q8_linear               M=2 N=3 K=32 max_abs=0.0021 rel_l2=0.00018
+[PASS] rms_norm                rows=2 dim=4096 max_abs=0.000006
+[PASS] rope_neox               T=2 H=4 D=128 start_pos=3 max_abs=0.000011
+[PASS] kv_cache_write          T=3 start_pos=2 exact=true
+[PASS] prefill_gqa_attention   T=3 Nq=4 Nkv=2 D=128 max_abs=0.000083
+[PASS] decode_gqa_attention    pos=2 Nq=4 Nkv=2 D=128 max_abs=0.000091
+[PASS] swiglu_tail             elements=257 max_abs=0.000004
+[PASS] greedy_tie              expected=17 actual=17
+SUMMARY passed=10 failed=0 skipped=0 elapsed_ms=...
+```
+
+stderr 只打印失败详情和 HIP/hipBLAS 错误。不要打印数千个元素。
+
+## 4. 测试 harness 的公共规则
+
+### 4.1 初始化和同步
+
+测试进程只创建：
+
+```text
+one HIP device
+one HIP stream
+one hipBLAS handle
+small reusable device buffers
+```
+
+并执行：
+
+```cpp
+hipSetDevice(0);
+hipStreamCreate(&stream);
+hipblasCreate(&handle);
+hipblasSetStream(handle, stream);
+```
+
+每个测试的正确顺序：
+
+```text
+prepare deterministic host input/reference
+  -> allocate/reuse small device buffers
+  -> H2D copy on the test stream
+  -> call the real exported wrapper
+  -> check immediate hipError_t/hipblasStatus_t
+  -> D2H copy on the same stream
+  -> hipStreamSynchronize once at the test boundary
+  -> finite check
+  -> numeric comparison
+  -> record metrics
+```
+
+不要在一个 kernel 尚未完成时从 host 读取输出。也不要依赖 `hipGetLastError()` 捕获异步执行错误。
+
+### 4.2 确定性输入
+
+优先使用显式公式：
+
+```cpp
+x[i] = 0.01f * static_cast<float>((i * 17) % 101 - 50);
+w[i] = 0.5f + 0.001f * static_cast<float>(i % 37);
+```
+
+若使用伪随机数，只允许固定 seed，例如：
+
+```cpp
+std::mt19937 rng(0x514E3308u);
+```
+
+禁止 `std::random_device`、当前时间 seed 或未初始化 device memory。
+
+输入必须包含：
+
+- 正数、负数、零和小数；
+- 不同 row/head/token 的不同值；
+- 非 block 整数倍的元素总数，用于检测尾部；
+- 非零 `start_pos`，用于检测 position/stride；
+- 相同最大 logits，用于检测 greedy tie-break。
+
+### 4.3 比较指标
+
+对 FP32 数组至少计算：
+
+```cpp
+max_abs = max(abs(actual[i] - reference[i]));
+
+max_rel = max(
+    abs(actual[i] - reference[i])
+    / max(abs(reference[i]), 1e-6f));
+
+rel_l2 = sqrt(sum((actual[i] - reference[i])^2))
+       / max(sqrt(sum(reference[i]^2)), 1e-12);
+```
+
+每次比较前必须检查：
+
+```text
+actual has no NaN
+actual has no Inf
+reference has no NaN/Inf
+element count matches
+```
+
+失败时记录最大误差元素：
+
+```text
+test=q8_linear
+shape=M2_N3_K32
+index=4
+reference=-1.28452
+actual=-1.30117
+abs_error=0.01665
+max_abs_limit=0.01
+```
+
+只有 FP16 cast/dequant 等明确要求 bit-exact 的测试可以比较 half bits。普通 FP32 运算禁止用 `memcmp`。
+
+### 4.4 初始容差
+
+| 测试 | `atol` | `rtol` / 额外要求 |
+| --- | ---: | ---: |
+| FP32 -> FP16 cast | exact half bits | 无 |
+| Q8_0 -> FP16 dequant | exact half bits | 无 |
+| Q8_0 embedding -> FP32 | `1e-6` | `1e-6` |
+| Q8 linear | `1e-2` | `1e-2`，并检查 `rel_l2 <= 1e-3` |
+| hidden/per-head RMSNorm | `1e-4` | `1e-4` |
+| NEOX RoPE | `1e-4` | `1e-4` |
+| KV cache write | exact FP32 values | 未写区域保持 canary |
+| prefill/decode attention | `1e-3` | `1e-3` |
+| SwiGLU | `1e-4` | `1e-4` |
+| add/add_inplace | `1e-6` | `1e-6` |
+| greedy argmax | token id exact | 相同值取更小 id |
+
+这些是 bring-up 上限，不是永远固定的宽松阈值。目标机建立稳定 baseline 后应收紧，不能为了让错误实现通过而扩大容差。
+
+## 5. 必须实现的快速测试
+
+### 5.1 FP32 到 FP16 cast
+
+入口：
+
+```cpp
+qwen3_z200_launch_cast_fp32_to_fp16(...);
+```
+
+测试：
+
+```text
+n_elements = 257
+```
+
+输入覆盖：
+
+```text
+0
+-0
+1
+-1
+small fractions
+large finite FP16 values
+positive and negative non-integers
+```
+
+CPU 使用与 IEEE FP16 一致的转换函数。比较每个 half 的 16-bit payload，并确认第 257 个尾部元素被写入。
+
+### 5.2 Q8_0 单 block 和多 block 反量化
+
+入口：
+
+```cpp
+qwen3_z200_launch_dequant_q8_0_to_fp16(...);
+```
+
+构造两个 block：
+
+```cpp
+BlockQ8_0 blocks[2];
+blocks[0].d = float_to_half(0.25f);
+blocks[1].d = float_to_half(0.03125f);
+
+for (int i = 0; i < 32; ++i) {
+    blocks[0].qs[i] = static_cast<int8_t>(i - 16);
+    blocks[1].qs[i] = static_cast<int8_t>(15 - i);
+}
+```
+
+CPU reference：
+
+```cpp
+for (size_t i = 0; i < 64; ++i) {
+    const BlockQ8_0& b = blocks[i / 32];
+    const float v = half_to_float(b.d)
+                  * static_cast<float>(b.qs[i % 32]);
+    expected[i] = float_to_half(v);
+}
+```
+
+检查：
+
+- `sizeof(BlockQ8_0) == 34`；
+- 64 个 half bit-exact；
+- `n_elements=63` 返回非法参数；
+- null pointer 和零元素返回非法参数。
+
+### 5.3 Q8_0 Embedding
+
+入口：
+
+```cpp
+qwen3_z200_launch_embedding_lookup_q8_0(...);
+```
+
+使用：
+
+```text
+vocab_size = 4
+hidden_dim = 64
+token_ids = [3, 1, 3]
+```
+
+每个 token row 使用不同 scale/quant pattern。CPU reference 按：
+
+```text
+block_idx = token_id * (hidden_dim / 32) + dim / 32
+value = fp16_scale * int8_quant
+```
+
+检查：
+
+- 重复 token 3 的两个输出 row 完全一致；
+- token 1 与 token 3 不同；
+- row-major `[T,H]` 顺序正确；
+- runtime 层应提前拒绝非法 token id。当前 kernel 的零填充行为不能替代 runtime 边界检查。
+
+### 5.4 Q8 Linear + hipBLAS
+
+入口：
+
+```cpp
+qwen3_z200_q8_linear_fp32(...);
+```
+
+固定 shape：
+
+```text
+M = 2
+N = 3
+K = 32
+X = [2,32] FP32
+W = [3,32] Q8_0
+Y = [2,3] FP32
+```
+
+CPU reference 必须复现真实 dtype 边界：
+
+```cpp
+x_half = fp32_to_fp16(x);
+w_half = q8_0_to_fp16(weight);
+
+for (int m = 0; m < M; ++m) {
+    for (int n = 0; n < N; ++n) {
+        float acc = 0.0f;
+        for (int k = 0; k < K; ++k) {
+            acc += half_to_float(x_half[m*K + k])
+                 * half_to_float(w_half[n*K + k]);
+        }
+        expected[m*N + n] = acc;
+    }
+}
+```
+
+不能用原始 FP32 `X` 或未 round 到 FP16 的反量化权重计算 reference，否则会把 dtype 差异误判为 GEMM 错误。
+
+额外检查：
+
+- `K=31` 被拒绝；
+- `x_workspace_elements < M*K` 被拒绝；
+- `weight_workspace_elements < N*K` 被拒绝；
+- 输出布局确实是 row-major `[M,N]`，不是转置的 `[N,M]`；
+- `beta=0`，预填充的输出 canary 不应参与结果。
+
+### 5.5 Hidden RMSNorm
+
+入口：
+
+```cpp
+qwen3_z200_launch_rms_norm(...);
+```
+
+固定 shape：
+
+```text
+rows = 2
+dim = 4096
+eps = 1e-6
+```
+
+CPU reference：
+
+```cpp
+double sum_sq = 0.0;
+for (int d = 0; d < dim; ++d) {
+    const double v = static_cast<double>(x[row*dim + d]);
+    sum_sq += v * v;
+}
+const float inv = 1.0f / sqrtf(
+    static_cast<float>(sum_sq / dim) + eps);
+expected[row*dim + d] = x[row*dim + d] * inv * weight[d];
+```
+
+CPU 使用 double 累加只是为了得到稳定 reference；比较仍允许 GPU FP32 reduction 顺序带来的小误差。两个 row 必须使用不同输入。
+
+### 5.6 Q/K per-head RMSNorm
+
+入口：
+
+```cpp
+qwen3_z200_launch_per_head_rms_norm(...);
+```
+
+至少两组：
+
+```text
+Q-like: T=2, n_heads=4, head_dim=128, row_stride=512
+K-like: T=2, n_heads=2, head_dim=128, row_stride=256
+```
+
+每个 `(token,head)` 单独计算 RMS，weight shape 是 `[128]`。不同 token/head 使用不同值，防止错误实现把整个 row 或所有 heads 一起归一化仍然通过。
+
+### 5.7 Qwen3 NEOX RoPE
+
+入口：
+
+```cpp
+qwen3_z200_launch_rope(...);
+```
+
+使用：
+
+```text
+T = 2
+n_heads = 4
+head_dim = 128
+row_stride = 512
+start_pos = 3
+max_position = 16
+rope_mode = 1  // ROPE_NEOX
+```
+
+CPU reference：
+
+```cpp
+const int half = head_dim / 2;
+const int i0 = pair;
+const int i1 = pair + half;
+const int pos = start_pos + token;
+
+expected[i0] = x0 * cos[pos][pair] - x1 * sin[pos][pair];
+expected[i1] = x0 * sin[pos][pair] + x1 * cos[pos][pair];
+```
+
+必须检查：
+
+- NEOX 是前后半区配对，不是 `(0,1),(2,3)`；
+- token 0 使用 position 3，token 1 使用 position 4；
+- Q-like `row_stride=512` 和 K-like stride 都测试；
+- `start_pos=0` 再增加一个基础 case，但不能只有 position 0。
+
+### 5.8 KV cache write
+
+入口：
+
+```cpp
+qwen3_z200_launch_kv_cache_write(...);
+```
+
+固定 shape：
+
+```text
+T = 3
+n_kv_heads = 2
+head_dim = 8
+max_seq_len = 8
+start_pos = 2
+```
+
+构造：
+
+```cpp
+src[token][head][dim] = token * 10000 + head * 100 + dim;
+```
+
+cache 初始化为可识别 canary。调用后要求：
+
+```text
+cache[2] == src[0]
+cache[3] == src[1]
+cache[4] == src[2]
+cache[0], cache[1], cache[5..7] remain canary
+K and V use independent patterns and are not swapped
+```
+
+### 5.9 Prefill 和 Decode GQA Attention
+
+入口：
+
+```cpp
+qwen3_z200_launch_prefill_gqa_attention(...);
+qwen3_z200_launch_decode_gqa_attention(...);
+```
+
+基础 CPU-reference case：
+
+```text
+T = 3
+n_heads = 4
+n_kv_heads = 2
+head_dim = 128
+max_seq_len = 8
+scale = 1 / sqrt(128)
+```
+
+GQA 映射：
+
+```cpp
+q_per_kv = n_heads / n_kv_heads; // 2
+kv_head = q_head / q_per_kv;
+```
+
+对每个 query token/head：
+
+```cpp
+for (int pos = 0; pos <= current_pos; ++pos) {
+    score[pos] = dot(q, k_cache[pos][kv_head]) * scale;
+}
+prob = stable_softmax(score);
+expected = sum(prob[pos] * v_cache[pos][kv_head]);
+```
+
+CPU softmax 必须先减最大值。检查：
+
+- prefill token `t` 只读取 `0..t`；
+- q heads `0,1` 映射 KV head 0，q heads `2,3` 映射 KV head 1；
+- prefill 最后 token 的输出与相同 Q/K/V、`current_pos=2` 的 decode 输出接近；
+- decode scores workspace 至少是 `[n_heads,max_seq_len]`；
+- 再增加一个 contract-shaped case：`n_heads=32,n_kv_heads=8,head_dim=128,T=2`，防止仅小 shape 通过而真实配置硬编码错误。
+
+### 5.10 SwiGLU 和 residual
+
+入口：
+
+```cpp
+qwen3_z200_launch_swiglu(...);
+qwen3_z200_launch_add(...);
+qwen3_z200_launch_add_inplace(...);
+```
+
+使用 `n_elements=257`，CPU：
+
+```cpp
+silu = gate / (1.0f + expf(-gate));
+expected_swiglu = silu * up;
+expected_add = a + b;
+```
+
+第 257 个元素必须参与计算。`add_inplace` 调用前保留输入副本，不能用已经修改的 `dst` 计算 expected。
+
+### 5.11 Greedy argmax
+
+入口：
+
+```cpp
+qwen3_z200_launch_greedy_sample(...);
+```
+
+使用：
+
+```text
+vocab_size = 513
+all logits initialized to a deterministic finite pattern
+logits[17] = 10
+logits[300] = 10
+```
+
+期望 token 是 17。再测试最大值位于：
+
+- id 0；
+- id 512；
+- 单一负数最大值；
+- vocab size 1。
+
+`out_token` 是初始化时分配的小 device buffer，不要在每个 case 中重复创建复杂 sampler 状态。
+
+## 6. CPU reference 的独立性
+
+CPU reference 只能实现数学公式和 layout，不能调用被测 GPU wrapper，也不能复用 GPU 输出作为中间 reference。
+
+允许共享：
+
+- `BlockQ8_0` 的明确 ABI 定义；
+- shape 常量；
+- 只读输入数据；
+- 通用的 half bit conversion helper。
+
+禁止共享：
+
+- GPU kernel 的实现循环；
+- device 输出；
+- 被测 wrapper 的索引 helper；
+- 为了迎合 GPU 错误而复制同一个错误 stride。
+
+建议 CPU reference 使用清晰的多维索引，而 GPU 输入仍是线性内存。例如 KV reference 写成：
+
+```cpp
+auto cache_index = [=](int pos, int head, int dim) {
+    return (static_cast<size_t>(pos) * n_kv_heads + head) * head_dim + dim;
+};
+```
+
+测试输入的不同 row/head/token 必须有不同值，才能让错误 stride 显现。
+
+## 7. 数值测试报告
+
+建议 JSON：
+
+```json
+{
+  "schema_version": 1,
+  "suite": "qwen3-z200-c0.1",
+  "device": "Z200SM_80",
+  "arch": "gfx906",
+  "passed": false,
+  "elapsed_ms": 24.8,
+  "summary": {
+    "passed": 9,
+    "failed": 1,
+    "skipped": 0
+  },
+  "cases": [
+    {
+      "name": "q8_linear",
+      "status": "fail",
+      "shape": "M=2,N=3,K=32",
+      "max_abs": 0.01665,
+      "max_rel": 0.01296,
+      "rel_l2": 0.00421,
+      "worst_index": 4,
+      "reference": -1.28452,
+      "actual": -1.30117,
+      "message": "max_abs 0.01665 exceeds 0.01"
+    }
+  ]
+}
+```
+
+报告中禁止写入模型权重或巨大 tensor dump。C0.1 不加载模型，报告通常应小于几百 KiB。
+
+## 8. B 阶段的上下游对接
+
+B 实现 Agent 的顺序：
+
+```text
+read 01/03/04/06/08 contracts
+  -> create qwen3_core
+  -> create server target
+  -> create qwen3_numeric_tests target linked to qwen3_core
+  -> implement independent CPU references
+  -> run bash build.sh
+  -> run ./build/qwen3_numeric_tests
+  -> only after C0.1 passes, boot serve.sh for HTTP smoke test
+```
+
+B 不得修改 system-owned `build.sh` 来绕过测试 target。若 numeric binary 没有被默认 build，应该修 `CMakeLists.txt`。
+
+B 完成前最低自测：
+
+```bash
+bash build.sh
+./build/qwen3_numeric_tests \
+  --report numeric-test-report.local.json
+./build/metainfer_cpp_server --help
+```
+
+如果快速测试失败，B 应先修具体 operator，不要启动并加载 8B 模型浪费时间。
+
+## 9. C 阶段的准确插入点
+
+当前 immutable C oracle 的主路径是：
+
+```text
+materialize_hardware_binding
+  -> _run_build_check(build.sh)
+  -> _start_server(serve.sh)
+  -> _wait_healthy
+  -> HTTP cases + judge
+```
+
+当前代码尚未自动运行 C0.1。接入后应变为：
+
+```text
+materialize_hardware_binding
+  -> _run_build_check(build.sh)
+  -> preflight_gpu(label="c0.1-numeric")
+  -> _run_numeric_check(build/qwen3_numeric_tests)   # new C0.1
+  -> _start_server(serve.sh)
+  -> _wait_healthy
+  -> HTTP cases + judge
+```
+
+建议在：
+
+```text
+MetaInfer/metainfer/tasks/gen_cpp_infer_framework/orchestrator/oracles/correctness.py
+```
+
+中 `_run_build_check()` 成功之后、`_start_server()` 之前调用：
+
+```python
+numeric_bin = iter_dir / "build" / "qwen3_numeric_tests"
+numeric_report = report_dir / "numeric-test-report.json"
+
+preflight = preflight_gpu(label="c0.1-numeric")
+if preflight.kill_errors:
+    raise NumericTestInfraError(
+        f"GPU preflight failed: {preflight.kill_errors}"
+    )
+
+ok, numeric_kind, numeric_err = _run_numeric_check(
+    numeric_bin,
+    numeric_report,
+    iter_dir=iter_dir,
+    report_dir=report_dir,
+    extra_env=hardware_env,
+    timeout_s=120,
+)
+if not ok:
+    if numeric_kind == "infra":
+        raise NumericTestInfraError(
+            numeric_err or "C0.1 numeric test infrastructure failed"
+        )
+    return self._fail(
+        report_dir,
+        numeric_err or "C0.1 numeric tests failed",
+    )
+```
+
+`_run_numeric_check()` 建议执行：
+
+```python
+stdout_path = report_dir / "numeric-test.stdout.log"
+stderr_path = report_dir / "numeric-test.stderr.log"
+with stdout_path.open("wb") as stdout_fp, stderr_path.open("wb") as stderr_fp:
+    completed = subprocess.run(
+        [str(numeric_bin), "--report", str(numeric_report)],
+        cwd=str(iter_dir),
+        env=env,
+        stdout=stdout_fp,
+        stderr=stderr_fp,
+        timeout=120,
+        check=False,
+    )
+```
+
+C 必须：
+
+- 每次 C attempt 都重新运行 numeric binary；
+- 检查 binary 存在且是普通文件；
+- 继承 hardware profile 的执行环境；
+- 保留 stdout、stderr 和 JSON report 到本 iteration 的 logs；
+- numeric fail 时不调用 `_start_server()`，不加载 GGUF；
+- GPU preflight/device 初始化/进程启动失败标记 infra failure；
+- 数值 mismatch、缺少 binary、非法 CLI/报告、程序崩溃和测试超时标记 logic failure，交给 C repair Agent；
+- 不允许实现 Agent编辑 immutable oracle 或伪造 report 代替执行 binary。
+
+当前 `pipeline._run_oracle_once()` 会把普通 `OracleResult(passed=false)` 映射为 `LOGIC_FAIL`，把 oracle 抛出的异常映射为 `INFRA_FAIL`。因此上面的 `NumericTestInfraError` 必须仅用于真实环境/设备失败；kernel hang、测试程序崩溃、binary 缺失和数值不匹配都应返回普通失败，进入修复流程，不能借异常绕过修复。
+
+## 10. C repair Agent 的输入
+
+C0.1 失败传给 repair Agent 的摘要至少包含：
+
+```text
+C0.1 numeric test failed
+binary: <iter_dir>/build/qwen3_numeric_tests
+case: q8_linear
+shape: M=2,N=3,K=32
+max_abs: 0.01665 limit=0.01
+rel_l2: 0.00421 limit=0.001
+worst_index: 4
+reference: -1.28452
+actual: -1.30117
+stdout: <logs>/numeric-test.stdout.log
+stderr: <logs>/numeric-test.stderr.log
+report: <logs>/numeric-test-report.json
+```
+
+推荐定位映射：
+
+| 失败 case | 优先检查 |
+| --- | --- |
+| cast | FP16 conversion、元素数、尾部 grid |
+| dequant | `BlockQ8_0` 34-byte ABI、scale、block/offset |
+| embedding | token row、blocks-per-row、重复 token |
+| q8_linear | FP16 workspace、M/N/K、hipBLAS transpose/ld、row-major output |
+| RMSNorm | reduction、eps、weight、row/head stride |
+| RoPE | NEOX half split、position、row stride、sin/cos order |
+| KV write | `start_pos+token`、KV head、K/V 指针 |
+| attention | causal range、GQA mapping、scale、stable softmax |
+| SwiGLU | gate/up 配对、尾部元素、`silu(gate)*up` |
+| greedy | 全 vocab 扫描、reduction、相同值取较小 id |
+
+## 11. 通过条件
+
+C0.1 只有同时满足以下条件才算通过：
+
+```text
+1. build/qwen3_numeric_tests exists and starts.
+2. It uses a real HIP device and the selected hardware profile.
+3. All required cases execute; no required case is silently skipped.
+4. Every wrapper status is success for valid inputs.
+5. Invalid-input cases return the expected error.
+6. All actual FP32 outputs are finite.
+7. Exact tests match exactly.
+8. Approximate tests satisfy their declared tolerances.
+9. Test process exits 0.
+10. JSON summary says failed=0 and agrees with the process exit code.
+```
+
+若 JSON 写入失败但所有数值测试通过，首版可以把它视为 reporting infra failure；不能仅凭 exit code 0 丢失所有诊断信息后继续。
+
+## 12. 明确不做的内容
+
+C0.1 不做：
+
+- 不加载 GGUF；
+- 不比较真实 Qwen3-8B `[151936]` logits；
+- 不跑 36 层完整模型；
+- 不比较生成文本；
+- 不测试 tokenizer/chat template；
+- 不启动 HTTP server；
+- 不测吞吐或延迟优化；
+- 不使用 llama.cpp、vLLM 或 GGML 作为运行时依赖；
+- 不修改 `build.sh`、hardware profile 或 profiler contract。
+
+这些边界使 C0.1 保持快速、确定、易定位。完整模型和 HTTP 验收继续由 runtime contract 与现有 C oracle 的后续阶段负责。
+
+## 13. 最小实现顺序
+
+实现 Agent 建议按以下顺序增加 case：
+
+1. test harness、HIP stream、report、compare helper；
+2. cast + Q8_0 dequant；
+3. Q8 embedding；
+4. Q8 linear + hipBLAS；
+5. hidden/per-head RMSNorm；
+6. NEOX RoPE；
+7. KV cache write；
+8. prefill/decode GQA attention；
+9. SwiGLU + add；
+10. greedy argmax；
+11. CMake default target 和 `ctest` 注册；
+12. B 本地运行 `bash build.sh && ./build/qwen3_numeric_tests`；
+13. MetaInfer C oracle 接入 `_run_numeric_check()`。
+
+不要先写 HTTP 测试来替代这里的数值比较。C0.1 的价值正是：在加载 8B 模型之前，用一个明确 case 和一个明确误差位置把底层算子问题暴露出来。

--- a/metainfer/tasks/gen_cpp_infer_framework/notebooks/09_continuous_batching_contract.md
+++ b/metainfer/tasks/gen_cpp_infer_framework/notebooks/09_continuous_batching_contract.md
@@ -1,0 +1,506 @@
+# Qwen3 HIP Runtime Continuous Batching 实现契约
+
+## 1. 目的与边界
+
+本文是给后续实现 agent 的工程契约。目标是在不引入 ggml、不替换现有 GGUF loader、保留 Q8_0/HIP 路径的前提下，将当前“多 HTTP 连接、单请求串行推理”改成 **continuous batching**。
+
+本文中的 *batch* 指一次 GPU forward 同时推进多条独立序列；不是等待多个完整请求凑齐后再整体执行的 static batching。
+
+本阶段必须实现：
+
+- 多个请求可以独立进入、取消、完成；
+- 所有活跃请求在每个 decode tick 各前进一步，并在同一次 GPU batch forward 中执行；
+- 每条序列有独立 KV cache、position、sampler、生成结果；
+- 模型权重仍只加载一份并全局只读；
+- GPU API 只由一个 scheduler 线程调用。
+
+本阶段不要求：
+
+- 引入 ggml、llama.cpp 源码或通用多模型支持；
+- continuous prefill（首版可先做 batch decode）；
+- paged KV cache、prefix cache、FlashAttention、speculative decoding；
+- OpenAI streaming（但接口和状态机应留出空间）。
+
+## 2. 当前实现与并发瓶颈
+
+当前 `Qwen3Engine::generate()` 以 `std::lock_guard<std::mutex> lock(mutex_)` 包住整个 prompt encode、prefill、逐 token decode 和采样过程。因此 HTTP server 虽然每连接一个线程，GPU inference 仍严格串行。
+
+现有 `Qwen3Runtime` 是**单序列状态机**：
+
+- `state_.current_pos`、`state_.n_prompt`、`state_.has_logits` 只有一份；
+- KV cache 为 `[layer][position][kv_head][head_dim]`；
+- `d_logits_`、`d_scores_`、Q/K/V/FFN scratch 都只有一份；
+- `reset()` 只把 position 等状态归零，不分配、不清空 KV cache；下一个请求从 position 0 覆盖旧 cache。
+
+因此不得删除 engine mutex 后直接并行调用当前 runtime：这样会同时覆盖 KV cache、scratch、logits 和 sampler 状态，产生数据竞争与错误输出。
+
+当前模型配置为 36 层、8 KV heads、head_dim 128、最大 context 4096，单条序列的 FP16 K/V cache 约为：
+
+```text
+36 × 2(K,V) × 4096 × 8 × 128 × 2 bytes
+= 603,979,776 bytes ≈ 0.56 GiB
+```
+
+这决定了并发 slot 数必须是显存预算的一部分，不能按请求即时无限创建。
+
+## 3. 参考 llama.cpp 的原则，但不引入 ggml
+
+llama.cpp 的核心设计是 `slot + sequence id + batch + KV memory`：一批 token 中每一项都有 token、position、sequence id；server scheduler 动态维护活跃 slot，然后调用一次 decode。
+
+本项目应复制这个**架构思想**，而不是复制 llama.cpp 或接入 ggml：
+
+```text
+llama.cpp 的 seq_id        → 本项目的 slot_id
+llama.cpp 的 llama_batch    → 本项目的 RuntimeBatch
+llama.cpp 的 server slot    → 本项目的 SequenceState
+llama.cpp 的 queue/loop     → 本项目的 Qwen3BatchScheduler
+```
+
+现有自定义 HIP runtime 与 kernel 可以继续使用；需要的是给 runtime 和 kernel 增加 batch/slot 维度。
+
+## 4. 目标线程模型（强制）
+
+```text
+多个 HTTP worker 线程
+  └─ Engine::generate() / submit()
+      └─ 短时持锁：向有界 pending queue 入队
+          └─ Qwen3BatchScheduler 的唯一 GPU worker 线程
+              ├─ 分配/释放 sequence slot
+              ├─ 合并 prefill 或 decode batch
+              ├─ 调用 runtime 的 GPU forward
+              ├─ 为每个 slot 独立采样、完成或继续
+              └─ 通过 promise/callback 通知 HTTP worker
+```
+
+规则：
+
+1. `Qwen3Runtime`、`hipStream_t`、`hipblasHandle_t`、GPU scratch 和 GPU KV pool 只能由 scheduler 的一个线程访问。
+2. HTTP 线程不得直接调用 `runtime.prefill()`、`runtime.decode()` 或 sampler。
+3. mutex 仍会存在，但只保护 host-side queue、slot 元数据、结果状态和 shutdown 状态；不得再保护整个 token generation loop。
+4. 首版使用一个 HIP stream 和一个 scheduler worker；多 stream/多 GPU 是后续独立课题。
+
+这既避免 CUDA/HIP 状态竞争，也让多请求在一次计算中获得 batching 效益。
+
+## 5. 推荐文件职责
+
+新增文件：
+
+```text
+src/qwen3_batch_scheduler.h
+src/qwen3_batch_scheduler.cpp
+```
+
+修改文件：
+
+```text
+src/engine.h / src/engine.cpp            // 对外提交请求、生命周期
+include/qwen3_runtime.h
+src/qwen3_runtime.cpp                    // RuntimeBatch、batch forward、GPU pool
+include/qwen3_z200_kernels.h
+src/qwen3_z200_kernels.hip.cpp           // slot_id/position-aware KV 和 attention
+src/qwen3_sampler.h / .cpp               // 每 sequence 一个 sampler state 或无状态采样 API
+src/main.cpp                              // 可选 CLI: --max-sequences / --max-batch-size
+CMakeLists.txt                            // 加入 scheduler source
+tests/qwen3_numeric_tests.cpp             // 多 slot kernel 正确性
+test.sh / test_spec.md                    // HTTP 并发与关闭测试
+```
+
+不要把 scheduler、HTTP socket 逻辑或 `std::thread` 放进 `qwen3_runtime.cpp`。runtime 是 GPU 执行器；scheduler 是主机端状态机；HTTP API 只是请求生产者。
+
+## 6. 公共接口契约
+
+### 6.1 保留的 HTTP/Engine 同步接口
+
+为避免先改 `openai_api.cpp`，保留现有同步 API：
+
+```cpp
+bool Qwen3Engine::generate(
+    const GenerateRequest &req,
+    GenerateResult *res,
+    std::string *error);
+```
+
+语义改为：
+
+1. 仅在 CPU 上完成 prompt format/tokenize；
+2. 建立 `SequenceRequest` 并投递给 scheduler；
+3. 等待该请求的 `std::future`；
+4. 从 scheduler 返回 `GenerateResult` 或错误。
+
+HTTP worker 因而可以阻塞等待自己的 future；它不占用 GPU，也不持有 runtime mutex。后续支持 streaming 时新增异步接口，不破坏上述同步接口。
+
+### 6.2 新增的 Engine API（建议）
+
+```cpp
+using GenerationFuture = std::future<GenerateResult>;
+
+GenerationFuture submit(const GenerateRequest &req, std::string *error);
+bool cancel(uint64_t request_id);
+void shutdown();
+```
+
+`generate()` 可以内部调用 `submit()` 再 `future.get()`。如果队列满，`submit()` 立即失败并设置错误；不要让无限请求堆积在 detached HTTP thread 中。
+
+### 6.3 scheduler API
+
+```cpp
+struct SchedulerConfig {
+    int32_t max_sequences = 4;       // KV slot 数，必须经显存预算确认
+    int32_t max_batch_size = 4;      // 单次 decode 最多 active slots
+    int32_t prefill_chunk_size = 128;
+    int32_t max_pending_requests = 64;
+};
+
+class Qwen3BatchScheduler {
+public:
+    Qwen3BatchScheduler(Qwen3Runtime &runtime,
+                         const Qwen3Tokenizer &tokenizer,
+                         SchedulerConfig cfg);
+    ~Qwen3BatchScheduler();
+
+    bool start(std::string *error);
+    std::future<GenerateResult> enqueue(SequenceRequest request,
+                                        std::string *error);
+    bool cancel(uint64_t request_id);
+    void stop_and_drain();
+};
+```
+
+不要求把 tokenizer 传给 scheduler：也可在 `Engine::submit()` 先 tokenize 并把 token id 传入。首版建议后者，使 scheduler 只管理已经 tokenized 的请求。
+
+## 7. sequence slot 与状态
+
+一个活跃请求必须对应一个独立的 `SequenceState`。建议的最小结构：
+
+```cpp
+enum class SequencePhase { Pending, Prefill, Decode, Finished, Failed, Cancelled };
+
+struct SamplerState {
+    std::mt19937 rng;
+    bool seeded = false;
+    uint64_t seed = 0;
+};
+
+struct SequenceState {
+    uint64_t request_id = 0;
+    int32_t slot_id = -1;             // [0, max_sequences)，独占 KV 区域
+    SequencePhase phase = SequencePhase::Pending;
+
+    std::vector<int32_t> prompt_tokens;
+    size_t prefill_cursor = 0;
+    int32_t position = 0;             // 当前已经写入 KV 的 token 数
+    int32_t next_input_token = -1;    // decode 下一轮要送入 runtime 的 token
+    std::vector<int32_t> generated_tokens;
+
+    SamplingParams sampling;
+    SamplerState sampler_state;        // 每请求 RNG/采样历史；禁止跨 request 共享
+    std::vector<int32_t> stop_token_ids;
+    int32_t max_new_tokens = 0;
+
+    std::promise<GenerateResult> completion;
+    std::atomic<bool> cancel_requested{false};
+    std::string error;
+};
+```
+
+约束：
+
+- `slot_id` 在 `Pending` 时为 -1；进入 GPU 执行前从空闲池取得；结束后才归还；
+- 每条序列的 `position` 独立，不能继续使用 runtime 全局 `state_.current_pos`；
+- 每条序列必须有独立 RNG。当前 `Qwen3Sampler` 将 RNG 存为成员，不可由所有 slot 共用；应改为 `SamplerState` 作为 sequence 成员，或把 sampler 改成显式接收 state；
+- 达到 EOS、stop token、`max_new_tokens`、context 上限、取消或 GPU error 时，必须只结束当前 slot，不能影响其他 slot。
+
+## 8. GPU 内存布局与容量
+
+### 8.1 权重（保持不变）
+
+`Qwen3GgufModel` 在启动时为每个 tensor 上传一份 GPU 内存，权重只读，全部 slot 共享。不要因为并发而复制权重。
+
+### 8.2 KV cache（必须重构）
+
+当前：
+
+```text
+K/V[layer][position][kv_head][head_dim]
+```
+
+目标：
+
+```text
+K/V[layer][slot][position][kv_head][head_dim]
+```
+
+推荐线性 offset：
+
+```cpp
+size_t kv_offset(
+    int layer, int slot, int pos, int kv_head, int dim) {
+    return (((((size_t) layer * max_sequences + slot) * max_seq_len + pos)
+             * n_kv_heads + kv_head) * head_dim + dim);
+}
+```
+
+实现可保留 `std::vector<KVCacheLayer>`，但每层的 `k`、`v` allocation 大小必须乘 `max_sequences`：
+
+```cpp
+sizeof(__half) * max_sequences * max_seq_len * n_kv_head * head_dim
+```
+
+为可控显存，启动时检查：
+
+```text
+required_kv_bytes = one_slot_kv_bytes × max_sequences
+```
+
+`hipMemGetInfo()` 后要确保还留有 weight、scratch 和安全余量；不足时 `initialize()` 明确报错，不能运行到 OOM。
+
+### 8.3 scratch 和 logits
+
+首版令 batch 上限 `B = max_batch_size`，将所有 token-row scratch 扩为 `[B, ...]`，包括：
+
+- `d_token_ids_`、`d_residual_`、`d_xb_`；
+- Q/K/V、norm、attention、FFN intermediate；
+- `d_scores_`：需至少 `[B, n_head, max_seq_len]`，或者按 sequence 轮流使用并确保 kernel 不重叠；
+- `d_logits_`：必须能够保存每条 batch row 的 vocab logits，即 `[B, vocab_size]`，或使用“forward 后立即逐 row sample”的等价安全设计。
+
+注意：仅把 KV cache 加 slot 维度还不够；当前 `d_logits_` 只有一行，batch 下会互相覆盖。
+
+## 9. RuntimeBatch 与 runtime 接口
+
+删除“runtime 自己保存全局请求 position”的假设。用显式 batch 描述输入：
+
+```cpp
+struct RuntimeBatch {
+    const int32_t *token_ids;      // [n_tokens]
+    const int32_t *positions;      // [n_tokens]，每行所属 sequence 的绝对 position
+    const int32_t *slot_ids;       // [n_tokens]，每行所属 KV slot
+    int32_t n_tokens = 0;          // 首版 decode: 每 sequence 一行
+    bool produce_logits = true;
+};
+
+bool Qwen3Runtime::forward_batch(
+    const RuntimeBatch &batch,
+    std::string *error);
+
+const float *Qwen3Runtime::device_logits_row(int32_t row) const;
+```
+
+首版限定：`n_tokens <= max_batch_size`，一个 slot 在一个 decode batch 中最多出现一次。这样最易实现与测试。
+
+原 `prefill()`/`decode()` 可暂时保留为 `slot=0` 的 compatibility wrapper，但 scheduler 不得调用它们。待新路径稳定后，删除 `Qwen3RuntimeState state_` 或降级为仅用于单请求测试。
+
+## 10. scheduler 状态机与 tick 算法
+
+### 10.1 入队和 slot 分配
+
+1. HTTP/Engine 完成 tokenize，构造 `SequenceRequest`；
+2. 在短锁下检查 `pending + active < max_pending_requests + max_sequences`；
+3. queue 满：立即错误（HTTP 应为 429 或 503），不创建 detached worker；
+4. scheduler 醒来，从 pending FIFO 取任务，分配空闲 slot；
+5. 设置 phase 为 `Prefill`。
+
+### 10.2 首版：prefill 不混合，decode 连续 batching
+
+为降低第一版难度，可采用：
+
+- 有空闲 slot 时，一个新请求单独或按同长度请求做 prompt prefill；
+- 已处于 Decode 的请求始终每 tick batch；
+- prompt 过长时按 `prefill_chunk_size` 分块，防止长请求垄断 GPU；
+- 新请求的 prefill 不得抢占无限多个 decode tick；建议每 N 个 decode tick 至少处理一个 prefill chunk。
+
+这已经是实用 continuous decode batching；后续再将 prefill chunk 与 decode token 混进同一个 batch。
+
+### 10.3 decode tick（必须满足的语义）
+
+伪代码：
+
+```cpp
+while (!stopping) {
+    admit_pending_requests_to_free_slots();
+    process_prefill_budgeted();
+
+    auto active = collect_slots(SequencePhase::Decode, cfg.max_batch_size);
+    if (active.empty()) {
+        wait_for_work_or_shutdown();
+        continue;
+    }
+
+    // one next-token input per active sequence
+    RuntimeBatch batch = make_decode_batch(active);
+    runtime.forward_batch(batch, &error);
+
+    for (int row = 0; row < batch.n_tokens; ++row) {
+        SequenceState &seq = active[row];
+        int token = sample_logits_for_row(seq, runtime.device_logits_row(row));
+        if (is_finished(seq, token)) {
+            complete_and_release(seq);
+        } else {
+            seq.generated_tokens.push_back(token);
+            seq.next_input_token = token;
+            ++seq.position;
+            // seq remains Decode and is automatically eligible next tick
+        }
+    }
+}
+```
+
+“continuous”的必要条件是：每轮重新收集 active slot；新到请求能在后续 tick 加入，结束请求能立即释放 slot，绝不能等待同一批全部生成完才接受新请求。
+
+### 10.4 cancel、错误、关闭
+
+- `cancel()` 只设置 `cancel_requested`；scheduler 在每个 tick 的 batch 构建前检查并结束它；
+- GPU forward 失败时，将本次 batch 中所有尚未完成的请求设为失败，并保留错误字符串；
+- scheduler 不得在持有 queue mutex 时运行 GPU、采样或调用 promise；
+- `stop_and_drain()`：停止接收新任务，唤醒 scheduler，允许当前已提交 GPU 工作完成或安全取消，然后为所有未完成 promise 设置异常/错误，再 join scheduler 线程；
+- 禁止 detached scheduler 线程。它必须是可 join 的成员线程，先 join 后析构 runtime/model。
+
+## 11. kernel 改造契约
+
+### 11.1 KV write
+
+旧函数依赖 `start_pos + t` 写入单个 cache。新接口至少需要每行 slot 和 position：
+
+```cpp
+hipError_t qwen3_z200_launch_kv_cache_write_fp16_batched(
+    const float *k_src, const float *v_src,
+    __half *k_cache, __half *v_cache,
+    const int32_t *slot_ids, const int32_t *positions,
+    int n_rows, int max_sequences, int max_seq_len,
+    int n_kv_heads, int head_dim, hipStream_t stream);
+```
+
+目标地址必须使用 `slot_ids[row]`、`positions[row]`。不得假定 row i 的位置等于 `start_pos + i`。
+
+### 11.2 RoPE
+
+旧 RoPE 使用连续 `start_pos + token_index`。batch decode 中每行的 position 不同，所以把 `positions` 传入 kernel：
+
+```text
+rope position = positions[row]
+```
+
+### 11.3 attention
+
+decode attention 要按 `row × q_head` 建 grid，每个 row：
+
+```text
+slot = slot_ids[row]
+seq_len = positions[row] + 1
+K/V base = cache[layer][slot][0]
+```
+
+每个 row 只能读自己的 slot，绝不能跨 slot。`d_scores_` 要按 row 切片。
+
+### 11.4 linear / LM head
+
+009 的 fused Q8_0 GEMV 只适合 `M==1`。目标选择策略：
+
+```text
+batch rows == 1 → 继续用 fused Q8_0 GEMV
+batch rows > 1  → 使用已有 q8_linear + hipBLAS GEMM 路径
+```
+
+不要为了第一版强行把 GEMV 扩成复杂 batched kernel。先确保多行路径数值正确、吞吐可测；batch GEMM 或 Q8 GEMM 可以后续单独优化。
+
+LM head 要为每 row 输出 logits。若临时用 `[B, vocab]` logits 内存，必须计入显存预算；若需降低内存，可后续实现 top-k/logit streaming，但不能让不同 row 复用同一 logits buffer 后再异步采样。
+
+## 12. sampler 改造契约
+
+现有 `Qwen3Sampler` 含 mutable RNG、host logits buffer 和 device next-token buffer，不能被多个 sequence 共享。首版可选两条路线：
+
+1. 每个 slot 一个 `Qwen3Sampler`（实现简单，注意各自 GPU buffer）；
+2. 一个无状态 `Qwen3Sampler` 服务对象 + `SamplerState`/RNG/host logits 作为每 sequence 参数（更节省，接口改动更大）。
+
+无论哪条路线，必须保证：
+
+- sequence A/B 的 seed 和随机数序列独立；
+- 同一个 request 相同 seed 的结果可复现（明确 re-seed 时机）；
+- `sample_logits_for_row()` 只读取该 row 的 logits；
+- temperature=0 的 greedy path 也支持 batch 行。
+
+## 13. 锁、所有权与禁止事项
+
+允许：
+
+- `std::mutex + std::condition_variable` 保护 pending queue、free slot list、shutdown flag；
+- `std::atomic<bool>` 作为 cancellation flag；
+- `std::promise/std::future` 将最终结果交回 HTTP thread；
+- RAII 管理 scheduler thread、GPU buffer 和 slot 释放。
+
+禁止：
+
+- 用全局 engine mutex 包住 scheduler 的整个运行周期；
+- 每个请求创建一个 `Qwen3Runtime` 或一套模型权重；
+- 每请求 `hipMalloc` / `hipFree` KV cache；
+- 多个线程直接调用同一个 runtime/stream/handle；
+- detached scheduler thread；
+- 在持有 queue mutex 时等待 GPU 或 future；
+- 只改 HTTP server 并认为实现了 batching。
+
+## 14. 实施阶段与验收
+
+### Phase A：可安全排队（不计作 batching）
+
+- 增加 scheduler thread 和有界队列；
+- `Engine::generate()` 改为 enqueue + wait；
+- runtime 仍单请求执行；
+- 目标：替代全局长 mutex、关闭安全、过载可控。
+
+### Phase B：多 slot KV + batch decode（continuous batching MVP）
+
+- KV cache 加 slot 维度；
+- scratch/logits 支持 `max_batch_size` 行；
+- 增加 `RuntimeBatch` 和 batched decode kernel；
+- 每 tick 从活跃 slot 取一个 token；
+- 目标：2+ 请求同时活跃时，实际单次 `forward_batch.n_tokens > 1`。
+
+### Phase C：公平性与 prefill 分块
+
+- prompt 分块；
+- 限制单次 prefill 预算，避免长 prompt 饿死 decode；
+- 新请求能够在旧请求生成期间进入；
+- 目标：长/短请求混合时短请求不会等待旧请求全部结束。
+
+### Phase D：性能优化
+
+- profile batch 1 与 batch >1；
+- 调整 GEMV/GEMM 分界；
+- 考虑 batched LM head、fused attention、paged KV 等。
+
+## 15. 测试矩阵（实现完成前不得声称支持并发）
+
+必须新增或更新测试：
+
+1. **KV slot 隔离**：两个 slot 写入不同 K/V 常量，attention 结果只依赖自己的 slot。
+2. **batched kernel vs 单请求**：相同的两个输入分别单独运行和 batch 运行，逐 row logits 在设定 FP16 容差内一致。
+3. **相同 seed 可复现**：同一请求单独执行与与其他请求并发执行，输出应一致（若产品定义不同，文档必须明确）。
+4. **2/4/最大 slot HTTP 并发**：每个响应 JSON 有效、非空、对应各自 prompt；记录总吞吐和每请求延迟。
+5. **slot 回收**：短请求结束后，后到请求可获得其 slot；不得出现 stale KV 泄漏。
+6. **queue 满**：返回清晰的过载错误，不崩溃、不无限创建线程。
+7. **cancel**：取消一个生成中请求不影响同 batch 的其他请求。
+8. **shutdown**：有 pending/active 请求时关闭，scheduler 被 join，所有调用者得到完成或受控错误，无 use-after-free。
+9. **单请求回归**：batch size 1 输出仍通过现有 numeric/HTTP 测试。
+
+性能验收至少记录：batch=1、2、4 的 aggregate tok/s、每请求 tok/s、TTFT、p50/p99、GPU 显存；不要仅报 aggregate tok/s。
+
+## 16. Agent 实施前检查清单
+
+- [ ] 阅读本文件以及 `src/engine.*`、`include/qwen3_runtime.h`、`src/qwen3_runtime.cpp`、`src/qwen3_z200_kernels.hip.cpp`。
+- [ ] 计算目标 `max_sequences` 的 KV、scratch、logits 显存，不凭感觉设置。
+- [ ] 先定义 `SequenceState`、`RuntimeBatch`、slot 生命周期与错误语义，再修改 kernel。
+- [ ] 保证模型权重只读共享、KV/scratch/logits 有正确 batch/slot 所有权。
+- [ ] 保证 scheduler 是唯一 GPU 调用者，删除旧的全程 engine mutex。
+- [ ] 首版只承诺 batch decode；未做 mixed prefill 前，不得宣称完整 vLLM 式调度。
+- [ ] 通过第 15 节测试后再调优 kernel。
+
+## 17. 完成定义
+
+满足以下全部条件，才可称为“已实现 continuous batching”：
+
+1. 同时到达的请求不会互相覆盖 KV cache；
+2. 两条及以上活跃 sequence 能出现在同一次 runtime batch forward；
+3. 新请求能在旧请求未结束时加入后续 batch；
+4. 已结束请求的 slot 被立即安全回收并复用；
+5. batch=1 行为正确且无回归；
+6. HTTP 并发、取消、过载、shutdown 均有自动化测试；
+7. 代码和 metrics 能证明 GPU 确实执行过 `batch_size > 1`，而不只是 HTTP 层并发。

--- a/metainfer/tasks/gen_cpp_infer_framework/notebooks/README.md
+++ b/metainfer/tasks/gen_cpp_infer_framework/notebooks/README.md
@@ -1,10 +1,26 @@
 # C++ Inference Framework Knowledge Base
 
-This task-owned knowledge base is reserved for the C++ framework's hardware,
-build, profiling, and model-runtime contracts.
+This task-owned knowledge base covers the fixed Qwen3-8B, single-Z200 C++
+inference path from hardware constraints through the HTTP serving interface.
 
-| Note | Purpose |
+Read only the notes needed for the current component, in the order shown
+below when implementing the complete framework.
+
+| Order | Note | Purpose |
+| ---: | --- | --- |
+| 1 | `01_hardware.md` | Z200 hardware, HIP environment, memory, wavefront, and launch constraints. |
+| 2 | `02_qwen3_forwrad compute.md` | Qwen3 forward graph and model-specific computation order. |
+| 3 | `03_qwen3_8b_contract.md` | Fixed Qwen3-8B config and model contract: independent weights, KV cache, prefill/decode, and validation. |
+| 4 | `04_qwen3_z200_operator_contract.md` | Z200 HIP calls, independent Q/K/V and gate/up linears, Q8_0 dequantization, hipBLAS GEMM, and workspaces. |
+| 5 | `05_qwen3_gguf_loader_notes.md` | GGUF parsing, fixed-config validation, move-only device-weight ownership, and tokenizer metadata handoff. |
+| 6 | `06_qwen3_runtime_notes.md` | Runtime buffers, RoPE/KV state, prefill/decode, logits/sampler boundary, and generation state machine. |
+| 7 | `07_qwen3_http_server_contract.md` | C++ HTTP server, OpenAI-compatible schema, `serve.sh`, process lifecycle, and pipeline-C acceptance contract. |
+| 8 | `08_qwen3_z200_numeric_test_contract.md` | C0.1 fast Z200 operator numeric tests, CPU references, CMake target sharing, reports, and build-to-HTTP pipeline integration. |
+| 9 | `09_continuous_batching_contract.md` | Multi-request continuous batching: scheduler, sequence slots, KV-cache ownership, runtime/kernel interfaces, concurrency safety, and acceptance tests. Read this before changing any B=1 runtime/HTTP concurrency rule. |
+
+Reference implementation assets in this directory:
+
+| File | Purpose |
 | --- | --- |
-| `02_qwen3_forwrad compute.md` | Qwen3 forward graph as implemented by llama.cpp. |
-| `03_qwen3_8b_cpp_contract.md` | Qwen3-8B C++ implementation contract: config, weights, KV cache, prefill/decode, and validation. |
-| `04_qwen3_z200_operator_contract.md` | Z200 HIP operator calls, Q8_0 dequantization, hipBLAS GEMM, workspaces, and single-GPU execution flow. |
+| `qwen3_z200_kernels.hip.cpp` | Current correctness-first HIP kernels and Q8_0 hipBLAS wrapper. |
+| `tokenizer.hpp` / `tokenizer.cpp` | Minimal Qwen3 byte-level BPE tokenizer and single-turn chat prompt formatting. |

--- a/metainfer/tasks/gen_cpp_infer_framework/notebooks/qwen3_z200_kernels.hip.cpp
+++ b/metainfer/tasks/gen_cpp_infer_framework/notebooks/qwen3_z200_kernels.hip.cpp
@@ -57,6 +57,7 @@ __global__ void cast_fp32_to_fp16_kernel(
     if (tid < n_elements) {
         out[tid] = __float2half(x[tid]);
     }
+    return;
 }
 
 __global__ void dequant_q8_0_to_fp16_kernel(
@@ -445,6 +446,48 @@ __global__ void swiglu_kernel(
     out[tid] = (g / (1.0f + expf(-g))) * up[tid];
 }
 
+__global__ void greedy_argmax_kernel(
+        const float * __restrict__ logits,
+        int vocab_size,
+        int * __restrict__ out_token) {
+    const int tid = threadIdx.x;
+    float best_val = -FLT_MAX;
+    int best_idx = 0;
+
+    for (int i = tid; i < vocab_size; i += blockDim.x) {
+        const float v = logits[i];
+        if (v > best_val || (v == best_val && i < best_idx)) {
+            best_val = v;
+            best_idx = i;
+        }
+    }
+
+    __shared__ float s_vals[kBlockSize];
+    __shared__ int s_idxs[kBlockSize];
+
+    s_vals[tid] = best_val;
+    s_idxs[tid] = best_idx;
+    __syncthreads();
+
+    for (int stride = blockDim.x >> 1; stride > 0; stride >>= 1) {
+        if (tid < stride) {
+            const float other_val = s_vals[tid + stride];
+            const int other_idx = s_idxs[tid + stride];
+            if (other_val > s_vals[tid]
+                    || (other_val == s_vals[tid] && other_idx < s_idxs[tid])) {
+                s_vals[tid] = other_val;
+                s_idxs[tid] = other_idx;
+            }
+        }
+        __syncthreads();
+    }
+
+    if (tid == 0) {
+        *out_token = s_idxs[0];
+    }
+    return;
+}
+
 __global__ void add_kernel(
         float * __restrict__ out,
         const float * __restrict__ a,
@@ -454,6 +497,7 @@ __global__ void add_kernel(
     if (tid < n_elements) {
         out[tid] = a[tid] + b[tid];
     }
+    return;
 }
 
 __global__ void add_inplace_kernel(
@@ -464,6 +508,7 @@ __global__ void add_inplace_kernel(
     if (tid < n_elements) {
         dst[tid] += src[tid];
     }
+    return;
 }
 
 } // namespace qwen3_z200
@@ -614,6 +659,9 @@ extern "C" hipblasStatus_t qwen3_z200_q8_linear_fp32(
 
     const float alpha = 1.0f;
     const float beta = 0.0f;
+    // DTK 5.7 exposes the legacy hipBLAS Ex API.  Its matrix and compute
+    // types are all hipblasDatatype_t, so use the HIPBLAS_R_* values rather
+    // than the hipDataType HIP_R_* values used by newer v2 headers.
     status = hipblasGemmEx(
             handle,
             HIPBLAS_OP_T,
@@ -623,16 +671,16 @@ extern "C" hipblasStatus_t qwen3_z200_q8_linear_fp32(
             k,
             &alpha,
             weight_fp16_workspace,
-            HIP_R_16F,
+            HIPBLAS_R_16F,
             k,
             x_fp16_workspace,
-            HIP_R_16F,
+            HIPBLAS_R_16F,
             k,
             &beta,
             out,
-            HIP_R_32F,
+            HIPBLAS_R_32F,
             n,
-            HIPBLAS_COMPUTE_32F,
+            HIPBLAS_R_32F,
             HIPBLAS_GEMM_DEFAULT);
 
     if (restore_pointer_mode) {
@@ -900,5 +948,26 @@ extern "C" hipError_t qwen3_z200_launch_add_inplace(
             dst,
             src,
             n_elements);
+    return hipGetLastError();
+}
+
+extern "C" hipError_t qwen3_z200_launch_greedy_sample(
+        const float * logits,
+        int vocab_size,
+        int * out_token,
+        hipStream_t stream) {
+    if (logits == nullptr || out_token == nullptr || vocab_size <= 0) {
+        return hipErrorInvalidValue;
+    }
+
+    hipLaunchKernelGGL(
+            qwen3_z200::greedy_argmax_kernel,
+            dim3(1),
+            dim3(qwen3_z200::kBlockSize),
+            0,
+            stream,
+            logits,
+            vocab_size,
+            out_token);
     return hipGetLastError();
 }

--- a/metainfer/tasks/gen_cpp_infer_framework/notebooks/tokenizer.cpp
+++ b/metainfer/tasks/gen_cpp_infer_framework/notebooks/tokenizer.cpp
@@ -1,0 +1,670 @@
+#include "tokenizer.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <limits>
+#include <stdexcept>
+
+namespace {
+
+bool starts_with_at(
+        const std::string& text,
+        size_t offset,
+        const std::string& needle) {
+    return offset <= text.size()
+            && needle.size() <= text.size() - offset
+            && text.compare(offset, needle.size(), needle) == 0;
+}
+
+char ascii_lower(char value) {
+    return static_cast<char>(std::tolower(static_cast<unsigned char>(value)));
+}
+
+bool ascii_case_equal_at(
+        const std::string& text,
+        size_t offset,
+        const char* needle) {
+    size_t length = 0;
+    while (needle[length] != '\0') {
+        ++length;
+    }
+    if (offset > text.size() || length > text.size() - offset) {
+        return false;
+    }
+    for (size_t i = 0; i < length; ++i) {
+        if (ascii_lower(text[offset + i]) != ascii_lower(needle[i])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+} // namespace
+
+size_t Qwen3Tokenizer::MergePairHash::operator()(
+        const MergePair& pair) const {
+    const size_t h1 = std::hash<std::string>{}(pair.first);
+    const size_t h2 = std::hash<std::string>{}(pair.second);
+    return h1 ^ (h2 + 0x9e3779b97f4a7c15ULL + (h1 << 6) + (h1 >> 2));
+}
+
+void Qwen3Tokenizer::clear() {
+    ready_ = false;
+    add_bos_token_ = false;
+    bos_token_id_ = -1;
+    eos_token_id_ = -1;
+    pad_token_id_ = -1;
+
+    id_to_token_.clear();
+    token_to_id_.clear();
+    merge_ranks_.clear();
+    atomic_token_ids_.clear();
+    control_token_ids_.clear();
+    atomic_tokens_by_length_.clear();
+    byte_decoder_.clear();
+    for (std::string& token : byte_encoder_) {
+        token.clear();
+    }
+}
+
+std::string Qwen3Tokenizer::utf8_from_codepoint(uint32_t cp) {
+    std::string out;
+    if (cp <= 0x7F) {
+        out.push_back(static_cast<char>(cp));
+    } else if (cp <= 0x7FF) {
+        out.push_back(static_cast<char>(0xC0 | (cp >> 6)));
+        out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+    } else if (cp <= 0xFFFF) {
+        out.push_back(static_cast<char>(0xE0 | (cp >> 12)));
+        out.push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
+        out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+    } else {
+        out.push_back(static_cast<char>(0xF0 | (cp >> 18)));
+        out.push_back(static_cast<char>(0x80 | ((cp >> 12) & 0x3F)));
+        out.push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
+        out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+    }
+    return out;
+}
+
+void Qwen3Tokenizer::build_byte_maps() {
+    std::vector<int> bytes;
+    std::vector<uint32_t> codepoints;
+
+    for (int value = '!'; value <= '~'; ++value) {
+        bytes.push_back(value);
+        codepoints.push_back(static_cast<uint32_t>(value));
+    }
+    for (int value = 0xA1; value <= 0xAC; ++value) {
+        bytes.push_back(value);
+        codepoints.push_back(static_cast<uint32_t>(value));
+    }
+    for (int value = 0xAE; value <= 0xFF; ++value) {
+        bytes.push_back(value);
+        codepoints.push_back(static_cast<uint32_t>(value));
+    }
+
+    std::array<bool, 256> present{};
+    for (int value : bytes) {
+        present[static_cast<size_t>(value)] = true;
+    }
+
+    uint32_t extra = 0;
+    for (int value = 0; value < 256; ++value) {
+        if (!present[static_cast<size_t>(value)]) {
+            bytes.push_back(value);
+            codepoints.push_back(256 + extra);
+            ++extra;
+        }
+    }
+
+    for (size_t i = 0; i < bytes.size(); ++i) {
+        const uint8_t byte = static_cast<uint8_t>(bytes[i]);
+        const uint32_t cp = codepoints[i];
+        byte_encoder_[byte] = utf8_from_codepoint(cp);
+        byte_decoder_[cp] = byte;
+    }
+}
+
+bool Qwen3Tokenizer::load(
+        const Qwen3TokenizerData& data,
+        std::string* error) {
+    clear();
+
+    auto fail = [&](const std::string& message) {
+        if (error != nullptr) {
+            *error = message;
+        }
+        clear();
+        return false;
+    };
+
+    if (!data.model.empty() && data.model != "gpt2") {
+        return fail("Qwen3 tokenizer requires tokenizer.ggml.model=gpt2, got: "
+                + data.model);
+    }
+    if (data.tokens.empty()) {
+        return fail("tokenizer.ggml.tokens is empty");
+    }
+    if (!data.token_types.empty()
+            && data.token_types.size() != data.tokens.size()) {
+        return fail("tokenizer.ggml.token_type length does not match tokens");
+    }
+
+    build_byte_maps();
+    id_to_token_ = data.tokens;
+    token_to_id_.reserve(id_to_token_.size());
+
+    for (size_t i = 0; i < id_to_token_.size(); ++i) {
+        const std::string& token = id_to_token_[i];
+        if (token_to_id_.find(token) != token_to_id_.end()) {
+            return fail("duplicate tokenizer token at id " + std::to_string(i));
+        }
+        token_to_id_[token] = static_cast<int32_t>(i);
+
+        const int32_t type = data.token_types.empty()
+                ? TOKEN_TYPE_NORMAL
+                : data.token_types[i];
+        if (type == TOKEN_TYPE_CONTROL || type == TOKEN_TYPE_USER_DEFINED) {
+            atomic_token_ids_.insert(static_cast<int32_t>(i));
+        }
+        if (type == TOKEN_TYPE_CONTROL) {
+            control_token_ids_.insert(static_cast<int32_t>(i));
+        }
+    }
+
+    merge_ranks_.reserve(data.merges.size());
+    for (size_t rank = 0; rank < data.merges.size(); ++rank) {
+        const std::string& merge = data.merges[rank];
+        const size_t separator = merge.find(' ');
+        if (separator == std::string::npos || separator == 0
+                || separator + 1 >= merge.size()) {
+            return fail("invalid BPE merge at rank " + std::to_string(rank));
+        }
+
+        MergePair pair{
+                merge.substr(0, separator),
+                merge.substr(separator + 1)};
+        merge_ranks_.emplace(std::move(pair), static_cast<int32_t>(rank));
+    }
+
+    auto validate_id = [&](int32_t id, const char* name) -> bool {
+        if (id < -1 || id >= static_cast<int32_t>(id_to_token_.size())) {
+            if (error != nullptr) {
+                *error = std::string(name) + " is outside tokenizer vocabulary";
+            }
+            return false;
+        }
+        return true;
+    };
+
+    if (!validate_id(data.bos_token_id, "bos_token_id")
+            || !validate_id(data.eos_token_id, "eos_token_id")
+            || !validate_id(data.pad_token_id, "pad_token_id")) {
+        clear();
+        return false;
+    }
+
+    bos_token_id_ = data.bos_token_id;
+    eos_token_id_ = data.eos_token_id;
+    pad_token_id_ = data.pad_token_id;
+    add_bos_token_ = data.add_bos_token;
+
+    // BOS/EOS/PAD are special by definition.  Keep them atomic and skippable
+    // even when an incomplete converter omitted tokenizer.ggml.token_type.
+    for (int32_t id : {bos_token_id_, eos_token_id_, pad_token_id_}) {
+        if (id >= 0) {
+            atomic_token_ids_.insert(id);
+            control_token_ids_.insert(id);
+        }
+    }
+
+    atomic_tokens_by_length_.reserve(atomic_token_ids_.size());
+    for (int32_t id : atomic_token_ids_) {
+        atomic_tokens_by_length_.emplace_back(id_to_token_[id], id);
+    }
+    std::sort(
+            atomic_tokens_by_length_.begin(),
+            atomic_tokens_by_length_.end(),
+            [](const auto& lhs, const auto& rhs) {
+                if (lhs.first.size() != rhs.first.size()) {
+                    return lhs.first.size() > rhs.first.size();
+                }
+                return lhs.first < rhs.first;
+            });
+
+    ready_ = true;
+    return true;
+}
+
+int32_t Qwen3Tokenizer::token_id(const std::string& token) const {
+    const auto it = token_to_id_.find(token);
+    return it == token_to_id_.end() ? -1 : it->second;
+}
+
+std::string Qwen3Tokenizer::id_word(int32_t token_id_value) const {
+    if (token_id_value < 0
+            || token_id_value >= static_cast<int32_t>(id_to_token_.size())) {
+        return "<UNK>";
+    }
+    return id_to_token_[token_id_value];
+}
+
+bool Qwen3Tokenizer::is_atomic_token(int32_t token_id_value) const {
+    return atomic_token_ids_.find(token_id_value) != atomic_token_ids_.end();
+}
+
+bool Qwen3Tokenizer::is_control_token(int32_t token_id_value) const {
+    return control_token_ids_.find(token_id_value) != control_token_ids_.end();
+}
+
+std::vector<Qwen3Tokenizer::Utf8Unit> Qwen3Tokenizer::utf8_units(
+        const std::string& text) {
+    std::vector<Utf8Unit> units;
+    size_t i = 0;
+    while (i < text.size()) {
+        const size_t begin = i;
+        const uint8_t first = static_cast<uint8_t>(text[i]);
+        uint32_t cp = first;
+        size_t length = 1;
+
+        if ((first & 0xE0) == 0xC0 && i + 1 < text.size()) {
+            cp = first & 0x1F;
+            length = 2;
+        } else if ((first & 0xF0) == 0xE0 && i + 2 < text.size()) {
+            cp = first & 0x0F;
+            length = 3;
+        } else if ((first & 0xF8) == 0xF0 && i + 3 < text.size()) {
+            cp = first & 0x07;
+            length = 4;
+        }
+
+        bool valid = length > 1;
+        for (size_t j = 1; j < length && valid; ++j) {
+            const uint8_t next = static_cast<uint8_t>(text[i + j]);
+            if ((next & 0xC0) != 0x80) {
+                valid = false;
+                break;
+            }
+            cp = (cp << 6) | (next & 0x3F);
+        }
+        if (!valid && length > 1) {
+            cp = first;
+            length = 1;
+        }
+
+        i += length;
+        units.push_back({cp, begin, i});
+    }
+    return units;
+}
+
+bool Qwen3Tokenizer::is_newline(uint32_t cp) {
+    return cp == '\r' || cp == '\n';
+}
+
+bool Qwen3Tokenizer::is_space(uint32_t cp) {
+    if (cp == ' ' || cp == '\t' || cp == '\n' || cp == '\r'
+            || cp == '\v' || cp == '\f') {
+        return true;
+    }
+    return cp == 0x0085 || cp == 0x00A0 || cp == 0x1680
+            || (cp >= 0x2000 && cp <= 0x200A)
+            || cp == 0x2028 || cp == 0x2029 || cp == 0x202F
+            || cp == 0x205F || cp == 0x3000;
+}
+
+bool Qwen3Tokenizer::is_number(uint32_t cp) {
+    if (cp >= '0' && cp <= '9') {
+        return true;
+    }
+    return (cp >= 0x0660 && cp <= 0x0669)
+            || (cp >= 0x06F0 && cp <= 0x06F9)
+            || (cp >= 0x0966 && cp <= 0x096F)
+            || (cp >= 0x09E6 && cp <= 0x09EF)
+            || (cp >= 0x0E50 && cp <= 0x0E59)
+            || (cp >= 0xFF10 && cp <= 0xFF19);
+}
+
+bool Qwen3Tokenizer::is_punctuation_or_symbol(uint32_t cp) {
+    if (cp < 128) {
+        return std::ispunct(static_cast<unsigned char>(cp)) != 0;
+    }
+    return (cp >= 0x2000 && cp <= 0x206F)
+            || (cp >= 0x20A0 && cp <= 0x20CF)
+            || (cp >= 0x2100 && cp <= 0x214F)
+            || (cp >= 0x2190 && cp <= 0x2BFF)
+            || (cp >= 0x3000 && cp <= 0x303F)
+            || (cp >= 0xFE10 && cp <= 0xFE1F)
+            || (cp >= 0xFE30 && cp <= 0xFE6F)
+            || (cp >= 0xFF01 && cp <= 0xFF0F)
+            || (cp >= 0xFF1A && cp <= 0xFF20)
+            || (cp >= 0xFF3B && cp <= 0xFF40)
+            || (cp >= 0xFF5B && cp <= 0xFF65)
+            || (cp >= 0x1F000 && cp <= 0x1FAFF);
+}
+
+bool Qwen3Tokenizer::is_letter(uint32_t cp) {
+    if ((cp >= 'a' && cp <= 'z') || (cp >= 'A' && cp <= 'Z')) {
+        return true;
+    }
+    if (cp < 128 || is_space(cp) || is_number(cp)
+            || is_punctuation_or_symbol(cp)) {
+        return false;
+    }
+    // C++17 has no Unicode general-category API.  Treat remaining valid
+    // non-ASCII codepoints as letters/marks, which covers common Qwen3 input
+    // scripts (CJK, kana, hangul, Cyrillic, Arabic and Devanagari).
+    return cp >= 0x80 && !(cp >= 0x7F && cp <= 0x9F);
+}
+
+std::vector<std::string> Qwen3Tokenizer::pretokenize(
+        const std::string& text) const {
+    const std::vector<Utf8Unit> units = utf8_units(text);
+    std::vector<std::string> pieces;
+    size_t i = 0;
+
+    auto add_piece = [&](size_t begin_unit, size_t end_unit) {
+        if (begin_unit >= end_unit) {
+            return;
+        }
+        pieces.push_back(text.substr(
+                units[begin_unit].begin,
+                units[end_unit - 1].end - units[begin_unit].begin));
+    };
+
+    while (i < units.size()) {
+        const size_t byte_offset = units[i].begin;
+
+        // Qwen regex first alternative: (?i:'s|'t|'re|'ve|'m|'ll|'d)
+        const char* contraction = nullptr;
+        for (const char* candidate : {"'re", "'ve", "'ll", "'s", "'t", "'m", "'d"}) {
+            if (ascii_case_equal_at(text, byte_offset, candidate)) {
+                contraction = candidate;
+                break;
+            }
+        }
+        if (contraction != nullptr) {
+            size_t length = 0;
+            while (contraction[length] != '\0') {
+                ++length;
+            }
+            const size_t end_byte = byte_offset + length;
+            size_t j = i;
+            while (j < units.size() && units[j].end <= end_byte) {
+                ++j;
+            }
+            add_piece(i, j);
+            i = j;
+            continue;
+        }
+
+        if (is_letter(units[i].codepoint)) {
+            size_t j = i + 1;
+            while (j < units.size() && is_letter(units[j].codepoint)) {
+                ++j;
+            }
+            add_piece(i, j);
+            i = j;
+            continue;
+        }
+
+        // [^\r\n\p{L}\p{N}]?\p{L}+
+        if (!is_newline(units[i].codepoint)
+                && !is_letter(units[i].codepoint)
+                && !is_number(units[i].codepoint)
+                && i + 1 < units.size()
+                && is_letter(units[i + 1].codepoint)) {
+            size_t j = i + 2;
+            while (j < units.size() && is_letter(units[j].codepoint)) {
+                ++j;
+            }
+            add_piece(i, j);
+            i = j;
+            continue;
+        }
+
+        // \p{N}: Qwen intentionally isolates one Unicode number at a time.
+        if (is_number(units[i].codepoint)) {
+            add_piece(i, i + 1);
+            ++i;
+            continue;
+        }
+
+        // Optional ASCII space followed by a run of non-space symbols.
+        size_t symbol_begin = i;
+        size_t symbol = i;
+        if (units[symbol].codepoint == ' ' && symbol + 1 < units.size()
+                && !is_space(units[symbol + 1].codepoint)
+                && !is_letter(units[symbol + 1].codepoint)
+                && !is_number(units[symbol + 1].codepoint)) {
+            ++symbol;
+        }
+        if (symbol < units.size()
+                && !is_space(units[symbol].codepoint)
+                && !is_letter(units[symbol].codepoint)
+                && !is_number(units[symbol].codepoint)) {
+            size_t j = symbol + 1;
+            while (j < units.size()
+                    && !is_space(units[j].codepoint)
+                    && !is_letter(units[j].codepoint)
+                    && !is_number(units[j].codepoint)) {
+                ++j;
+            }
+            while (j < units.size() && is_newline(units[j].codepoint)) {
+                ++j;
+            }
+            add_piece(symbol_begin, j);
+            i = j;
+            continue;
+        }
+
+        if (is_space(units[i].codepoint)) {
+            size_t run_end = i + 1;
+            size_t last_newline = std::numeric_limits<size_t>::max();
+            if (is_newline(units[i].codepoint)) {
+                last_newline = i;
+            }
+            while (run_end < units.size() && is_space(units[run_end].codepoint)) {
+                if (is_newline(units[run_end].codepoint)) {
+                    last_newline = run_end;
+                }
+                ++run_end;
+            }
+            const size_t piece_end = last_newline == std::numeric_limits<size_t>::max()
+                    ? run_end
+                    : last_newline + 1;
+            add_piece(i, piece_end);
+            i = piece_end;
+            continue;
+        }
+
+        add_piece(i, i + 1);
+        ++i;
+    }
+
+    return pieces;
+}
+
+std::vector<std::string> Qwen3Tokenizer::bpe(
+        const std::string& piece) const {
+    std::vector<std::string> symbols;
+    symbols.reserve(piece.size());
+    for (unsigned char byte : piece) {
+        symbols.push_back(byte_encoder_[byte]);
+    }
+
+    while (symbols.size() >= 2) {
+        int32_t best_rank = std::numeric_limits<int32_t>::max();
+        MergePair best_pair;
+        bool found = false;
+
+        for (size_t i = 0; i + 1 < symbols.size(); ++i) {
+            MergePair pair{symbols[i], symbols[i + 1]};
+            const auto it = merge_ranks_.find(pair);
+            if (it != merge_ranks_.end() && it->second < best_rank) {
+                best_rank = it->second;
+                best_pair = std::move(pair);
+                found = true;
+            }
+        }
+        if (!found) {
+            break;
+        }
+
+        std::vector<std::string> merged;
+        merged.reserve(symbols.size());
+        for (size_t i = 0; i < symbols.size();) {
+            if (i + 1 < symbols.size()
+                    && symbols[i] == best_pair.first
+                    && symbols[i + 1] == best_pair.second) {
+                merged.push_back(symbols[i] + symbols[i + 1]);
+                i += 2;
+            } else {
+                merged.push_back(std::move(symbols[i]));
+                ++i;
+            }
+        }
+        symbols = std::move(merged);
+    }
+
+    return symbols;
+}
+
+std::vector<int32_t> Qwen3Tokenizer::encode_normal(
+        const std::string& text) const {
+    std::vector<int32_t> result;
+    for (const std::string& piece : pretokenize(text)) {
+        const std::vector<std::string> symbols = bpe(piece);
+        for (const std::string& symbol : symbols) {
+            const auto it = token_to_id_.find(symbol);
+            if (it == token_to_id_.end()) {
+                throw std::runtime_error(
+                        "Qwen3 tokenizer vocabulary is missing byte/BPE token");
+            }
+            result.push_back(it->second);
+        }
+    }
+    return result;
+}
+
+std::vector<int32_t> Qwen3Tokenizer::encode(
+        const std::string& text,
+        const Qwen3EncodeOptions& options) const {
+    if (!ready_) {
+        throw std::runtime_error("Qwen3 tokenizer is not loaded");
+    }
+
+    std::vector<int32_t> result;
+    const bool add_bos = options.add_bos || add_bos_token_;
+    if (add_bos && bos_token_id_ >= 0) {
+        result.push_back(bos_token_id_);
+    }
+
+    if (!options.parse_special || atomic_tokens_by_length_.empty()) {
+        std::vector<int32_t> normal = encode_normal(text);
+        result.insert(result.end(), normal.begin(), normal.end());
+    } else {
+        size_t normal_begin = 0;
+        size_t offset = 0;
+        while (offset < text.size()) {
+            int32_t special_id = -1;
+            size_t special_length = 0;
+            for (const auto& entry : atomic_tokens_by_length_) {
+                if (starts_with_at(text, offset, entry.first)) {
+                    special_id = entry.second;
+                    special_length = entry.first.size();
+                    break;
+                }
+            }
+
+            if (special_id < 0) {
+                ++offset;
+                continue;
+            }
+
+            if (normal_begin < offset) {
+                std::vector<int32_t> normal = encode_normal(
+                        text.substr(normal_begin, offset - normal_begin));
+                result.insert(result.end(), normal.begin(), normal.end());
+            }
+            result.push_back(special_id);
+            offset += special_length;
+            normal_begin = offset;
+        }
+        if (normal_begin < text.size()) {
+            std::vector<int32_t> normal = encode_normal(text.substr(normal_begin));
+            result.insert(result.end(), normal.begin(), normal.end());
+        }
+    }
+
+    if (options.add_eos && eos_token_id_ >= 0) {
+        result.push_back(eos_token_id_);
+    }
+    return result;
+}
+
+std::vector<int32_t> Qwen3Tokenizer::encode(
+        const std::string& text,
+        bool add_bos,
+        bool add_eos) const {
+    Qwen3EncodeOptions options;
+    options.parse_special = true;
+    options.add_bos = add_bos;
+    options.add_eos = add_eos;
+    return encode(text, options);
+}
+
+std::string Qwen3Tokenizer::decode(
+        const std::vector<int32_t>& token_ids,
+        bool skip_special) const {
+    if (!ready_) {
+        throw std::runtime_error("Qwen3 tokenizer is not loaded");
+    }
+
+    std::string result;
+    for (int32_t id : token_ids) {
+        if (id < 0 || id >= static_cast<int32_t>(id_to_token_.size())) {
+            throw std::out_of_range("token id outside Qwen3 vocabulary");
+        }
+        if (skip_special && is_control_token(id)) {
+            continue;
+        }
+
+        const std::string& token = id_to_token_[id];
+        if (is_atomic_token(id)) {
+            result += token;
+            continue;
+        }
+
+        for (const Utf8Unit& unit : utf8_units(token)) {
+            const auto byte = byte_decoder_.find(unit.codepoint);
+            if (byte != byte_decoder_.end()) {
+                result.push_back(static_cast<char>(byte->second));
+            } else {
+                result.append(token, unit.begin, unit.end - unit.begin);
+            }
+        }
+    }
+    return result;
+}
+
+std::string Qwen3Tokenizer::format_chat_prompt(
+        const std::string& user_text,
+        const std::string& system_text,
+        bool enable_thinking) const {
+    std::string prompt;
+    if (!system_text.empty()) {
+        prompt += "<|im_start|>system\n";
+        prompt += system_text;
+        prompt += "<|im_end|>\n";
+    }
+    prompt += "<|im_start|>user\n";
+    prompt += user_text;
+    prompt += "<|im_end|>\n";
+    prompt += "<|im_start|>assistant\n";
+    if (!enable_thinking) {
+        prompt += "<think>\n\n</think>\n\n";
+    }
+    return prompt;
+}

--- a/metainfer/tasks/gen_cpp_infer_framework/notebooks/tokenizer.hpp
+++ b/metainfer/tasks/gen_cpp_infer_framework/notebooks/tokenizer.hpp
@@ -1,0 +1,151 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+// Minimal Qwen3/Qwen2 byte-level BPE tokenizer contract.
+//
+// The GGUF loader owns file parsing and fills this structure from:
+//   tokenizer.ggml.model
+//   tokenizer.ggml.pre
+//   tokenizer.ggml.tokens
+//   tokenizer.ggml.merges
+//   tokenizer.ggml.token_type
+//   tokenizer.ggml.{bos,eos,padding}_token_id
+//
+// Qwen3 input is expected to be valid UTF-8 in NFC form.  The implementation
+// intentionally has no ICU/utf8proc dependency, so it cannot normalize a
+// decomposed Unicode string to NFC by itself.
+struct Qwen3TokenizerData {
+    std::string model;
+    std::string pre_tokenizer;
+    std::vector<std::string> tokens;
+    std::vector<std::string> merges;
+    std::vector<int32_t> token_types;
+
+    int32_t bos_token_id = -1;
+    int32_t eos_token_id = -1;
+    int32_t pad_token_id = -1;
+    bool add_bos_token = false;
+};
+
+struct Qwen3EncodeOptions {
+    // Recognize CONTROL and USER_DEFINED GGUF tokens such as <|im_start|>
+    // atomically.  Chat prompts must enable this.
+    bool parse_special = true;
+    bool add_bos = false;
+    bool add_eos = false;
+};
+
+class Qwen3Tokenizer {
+public:
+    // GGML vocabulary token types stored in tokenizer.ggml.token_type.
+    enum TokenType : int32_t {
+        TOKEN_TYPE_NORMAL       = 1,
+        TOKEN_TYPE_UNKNOWN      = 2,
+        TOKEN_TYPE_CONTROL      = 3,
+        TOKEN_TYPE_USER_DEFINED = 4,
+        TOKEN_TYPE_UNUSED       = 5,
+        TOKEN_TYPE_BYTE         = 6,
+    };
+
+    bool load(const Qwen3TokenizerData& data, std::string* error = nullptr);
+
+    bool ready() const { return ready_; }
+    size_t vocab_size() const { return id_to_token_.size(); }
+
+    std::vector<int32_t> encode(
+            const std::string& text,
+            const Qwen3EncodeOptions& options = {}) const;
+
+    // Compatibility with the previous notebook API.  Qwen3 normally has no
+    // BOS, so add_bos only has an effect when GGUF provides a valid BOS id.
+    std::vector<int32_t> encode(
+            const std::string& text,
+            bool add_bos,
+            bool add_eos) const;
+
+    std::string decode(
+            const std::vector<int32_t>& token_ids,
+            bool skip_special = true) const;
+
+    std::string id_word(int32_t token_id) const;
+    int32_t token_id(const std::string& token) const;
+
+    int32_t bos_token_id() const { return bos_token_id_; }
+    int32_t eos_token_id() const { return eos_token_id_; }
+    int32_t pad_token_id() const { return pad_token_id_; }
+
+    // Minimal single-turn form of the official Qwen3 chat template.  The
+    // returned string must be encoded with parse_special=true.
+    std::string format_chat_prompt(
+            const std::string& user_text,
+            const std::string& system_text = {},
+            bool enable_thinking = true) const;
+
+private:
+    struct MergePair {
+        std::string first;
+        std::string second;
+
+        bool operator==(const MergePair& other) const {
+            return first == other.first && second == other.second;
+        }
+    };
+
+    struct MergePairHash {
+        size_t operator()(const MergePair& pair) const;
+    };
+
+    struct Utf8Unit {
+        uint32_t codepoint;
+        size_t begin;
+        size_t end;
+    };
+
+    void clear();
+    void build_byte_maps();
+
+    std::vector<int32_t> encode_normal(const std::string& text) const;
+    std::vector<std::string> pretokenize(const std::string& text) const;
+    std::vector<std::string> bpe(const std::string& piece) const;
+
+    static std::vector<Utf8Unit> utf8_units(const std::string& text);
+    static std::string utf8_from_codepoint(uint32_t codepoint);
+    static bool is_letter(uint32_t codepoint);
+    static bool is_number(uint32_t codepoint);
+    static bool is_space(uint32_t codepoint);
+    static bool is_newline(uint32_t codepoint);
+    static bool is_punctuation_or_symbol(uint32_t codepoint);
+
+    bool is_atomic_token(int32_t token_id) const;
+    bool is_control_token(int32_t token_id) const;
+
+private:
+    bool ready_ = false;
+    bool add_bos_token_ = false;
+
+    int32_t bos_token_id_ = -1;
+    int32_t eos_token_id_ = -1;
+    int32_t pad_token_id_ = -1;
+
+    std::vector<std::string> id_to_token_;
+    std::unordered_map<std::string, int32_t> token_to_id_;
+    std::unordered_map<MergePair, int32_t, MergePairHash> merge_ranks_;
+
+    std::unordered_set<int32_t> atomic_token_ids_;
+    std::unordered_set<int32_t> control_token_ids_;
+    std::vector<std::pair<std::string, int32_t>> atomic_tokens_by_length_;
+
+    std::array<std::string, 256> byte_encoder_;
+    std::unordered_map<uint32_t, uint8_t> byte_decoder_;
+};
+
+// Keep the old class spelling usable by small examples that included the
+// original tokenizer.hpp.
+using tokenizer = Qwen3Tokenizer;

--- a/metainfer/tasks/gen_cpp_infer_framework/orchestrator/oracles/perf.py
+++ b/metainfer/tasks/gen_cpp_infer_framework/orchestrator/oracles/perf.py
@@ -71,12 +71,12 @@ DEFAULT_CONCURRENCY_LADDER = (1, 4, 16)
 # We take the median tokens_per_sec as the headline and report stdev so
 # the F-step planner can see whether differences between iterations are
 # larger than the run-to-run noise.
-RUNS_PER_LEVEL = 3
+RUNS_PER_LEVEL = 1
 
 # Drop this many initial requests per run before measuring. Warmup
 # absorbs: first-call kernel compilation, weight preloading, KV cache
 # pool allocation, JIT cache misses.
-WARMUP_REQUESTS = 4
+WARMUP_REQUESTS = 1
 
 # Per-request HTTP timeout (seconds). Generous because long-output
 # prompts can legitimately take 30+ seconds at low concurrency on big

--- a/metainfer/tasks/gen_cpp_infer_framework/tests/qwen3_z200_smoke.cpp
+++ b/metainfer/tasks/gen_cpp_infer_framework/tests/qwen3_z200_smoke.cpp
@@ -1,0 +1,83 @@
+#include <hip/hip_runtime.h>
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+
+extern "C" hipError_t qwen3_z200_launch_add(
+        float*, const float*, const float*, int, hipStream_t);
+extern "C" hipError_t qwen3_z200_launch_rms_norm(
+        float*, const float*, const float*, int, int, float, hipStream_t);
+extern "C" hipError_t qwen3_z200_launch_greedy_sample(
+        const float*, int, int*, hipStream_t);
+
+static void check(hipError_t status, const char* where) {
+    if (status != hipSuccess) {
+        std::fprintf(stderr, "%s: %s\n", where, hipGetErrorString(status));
+        std::exit(1);
+    }
+}
+
+int main() {
+    constexpr int n = 8;
+    const float a[n] = {1, 2, 3, 4, 5, 6, 7, 8};
+    const float b[n] = {8, 7, 6, 5, 4, 3, 2, 1};
+    const float weight[n] = {1, 1, 1, 1, 1, 1, 1, 1};
+
+    float* device_a = nullptr;
+    float* device_b = nullptr;
+    float* device_weight = nullptr;
+    float* device_out = nullptr;
+    int* device_token = nullptr;
+    check(hipMalloc(&device_a, sizeof(a)), "hipMalloc(a)");
+    check(hipMalloc(&device_b, sizeof(b)), "hipMalloc(b)");
+    check(hipMalloc(&device_weight, sizeof(weight)), "hipMalloc(weight)");
+    check(hipMalloc(&device_out, sizeof(a)), "hipMalloc(out)");
+    check(hipMalloc(&device_token, sizeof(int)), "hipMalloc(token)");
+    check(hipMemcpy(device_a, a, sizeof(a), hipMemcpyHostToDevice), "copy(a)");
+    check(hipMemcpy(device_b, b, sizeof(b), hipMemcpyHostToDevice), "copy(b)");
+    check(hipMemcpy(
+            device_weight, weight, sizeof(weight), hipMemcpyHostToDevice),
+            "copy(weight)");
+
+    check(qwen3_z200_launch_add(
+            device_out, device_a, device_b, n, nullptr), "launch(add)");
+    float out[n];
+    check(hipMemcpy(out, device_out, sizeof(out), hipMemcpyDeviceToHost),
+          "copy(add result)");
+    for (float value : out) {
+        if (std::fabs(value - 9.0f) > 1e-6f) return 2;
+    }
+
+    check(qwen3_z200_launch_rms_norm(
+            device_out, device_a, device_weight, 1, n, 1e-6f, nullptr),
+            "launch(rms_norm)");
+    check(hipMemcpy(out, device_out, sizeof(out), hipMemcpyDeviceToHost),
+          "copy(rms_norm result)");
+    float sum_squares = 0.0f;
+    for (float value : a) sum_squares += value * value;
+    const float inverse_rms = 1.0f / std::sqrt(sum_squares / n + 1e-6f);
+    for (int i = 0; i < n; ++i) {
+        if (std::fabs(out[i] - a[i] * inverse_rms) > 1e-5f) return 3;
+    }
+
+    check(qwen3_z200_launch_greedy_sample(
+            device_a, n, device_token, nullptr), "launch(greedy)");
+    int token = -1;
+    check(hipMemcpy(
+            &token, device_token, sizeof(token), hipMemcpyDeviceToHost),
+            "copy(greedy result)");
+    if (token != 7) return 4;
+
+    int device_count = 0;
+    check(hipGetDeviceCount(&device_count), "hipGetDeviceCount");
+    std::printf("PASS devices=%d add=9 rms0=%.6f greedy=%d\n",
+                device_count, out[0], token);
+
+    check(hipFree(device_a), "hipFree(a)");
+    check(hipFree(device_b), "hipFree(b)");
+    check(hipFree(device_weight), "hipFree(weight)");
+    check(hipFree(device_out), "hipFree(out)");
+    check(hipFree(device_token), "hipFree(token)");
+    return 0;
+}

--- a/metainfer/tasks/gen_cpp_infer_framework/tests/test_qwen3_tokenizer_contract.py
+++ b/metainfer/tasks/gen_cpp_infer_framework/tests/test_qwen3_tokenizer_contract.py
@@ -1,0 +1,185 @@
+"""Compile and exercise the standalone Qwen3 byte-level BPE tokenizer."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+TASK_DIR = Path(__file__).parents[1]
+TOKENIZER_CPP = TASK_DIR / "notebooks" / "tokenizer.cpp"
+TOKENIZER_HPP = TASK_DIR / "notebooks" / "tokenizer.hpp"
+LOADER_NOTES = TASK_DIR / "notebooks" / "05_qwen3_gguf_loader_notes.md"
+
+
+def test_qwen3_tokenizer_source_uses_gguf_bpe_contract():
+    header = TOKENIZER_HPP.read_text(encoding="utf-8")
+    source = TOKENIZER_CPP.read_text(encoding="utf-8")
+    loader_notes = LOADER_NOTES.read_text(encoding="utf-8")
+
+    assert "Qwen3TokenizerData" in header
+    assert "tokenizer.ggml.tokens" in header
+    assert "tokenizer.ggml.merges" in header
+    assert "merge_ranks_" in header
+    assert "byte_encoder_" in header
+    assert "format_chat_prompt" in header
+
+    assert 'data.model != "gpt2"' in source
+    assert "add_prefix_space" not in source
+    assert "vocab_scores" not in source
+    assert "tokens.push_back(1)" not in source
+    assert "tokens.push_back(2)" not in source
+    assert "Qwen3TokenizerData" in loader_notes
+    assert "不要再生成或读取旧式 `tokenizer.bin`" in loader_notes
+
+
+def test_qwen3_tokenizer_compiles_and_round_trips_utf8(tmp_path: Path):
+    harness = tmp_path / "tokenizer_test.cpp"
+    binary = tmp_path / "tokenizer_test"
+    harness.write_text(
+        r'''
+#include "tokenizer.hpp"
+
+#include <array>
+#include <cassert>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+static std::string utf8(uint32_t cp) {
+    std::string out;
+    if (cp <= 0x7f) {
+        out.push_back(static_cast<char>(cp));
+    } else if (cp <= 0x7ff) {
+        out.push_back(static_cast<char>(0xc0 | (cp >> 6)));
+        out.push_back(static_cast<char>(0x80 | (cp & 0x3f)));
+    } else {
+        out.push_back(static_cast<char>(0xe0 | (cp >> 12)));
+        out.push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3f)));
+        out.push_back(static_cast<char>(0x80 | (cp & 0x3f)));
+    }
+    return out;
+}
+
+static std::array<std::string, 256> byte_tokens() {
+    std::vector<int> bytes;
+    std::vector<uint32_t> codepoints;
+    for (int value = '!'; value <= '~'; ++value) {
+        bytes.push_back(value);
+        codepoints.push_back(value);
+    }
+    for (int value = 0xa1; value <= 0xac; ++value) {
+        bytes.push_back(value);
+        codepoints.push_back(value);
+    }
+    for (int value = 0xae; value <= 0xff; ++value) {
+        bytes.push_back(value);
+        codepoints.push_back(value);
+    }
+    std::array<bool, 256> present{};
+    for (int value : bytes) present[value] = true;
+    uint32_t extra = 0;
+    for (int value = 0; value < 256; ++value) {
+        if (!present[value]) {
+            bytes.push_back(value);
+            codepoints.push_back(256 + extra++);
+        }
+    }
+    std::array<std::string, 256> result;
+    for (size_t i = 0; i < bytes.size(); ++i) {
+        result[bytes[i]] = utf8(codepoints[i]);
+    }
+    return result;
+}
+
+int main() {
+    Qwen3TokenizerData data;
+    data.model = "gpt2";
+    const auto base = byte_tokens();
+    data.tokens.assign(base.begin(), base.end());
+    data.token_types.assign(256, Qwen3Tokenizer::TOKEN_TYPE_NORMAL);
+
+    data.tokens.push_back("he");       // 256
+    data.tokens.push_back("ll");       // 257
+    data.tokens.push_back("hell");     // 258
+    data.tokens.push_back("hello");    // 259
+    data.tokens.push_back(base[' '] + std::string("hello")); // 260
+    data.tokens.push_back("<|im_start|>"); // 261
+    data.tokens.push_back("<|im_end|>");   // 262
+    data.token_types.resize(263, Qwen3Tokenizer::TOKEN_TYPE_NORMAL);
+    data.token_types[261] = Qwen3Tokenizer::TOKEN_TYPE_CONTROL;
+    data.token_types[262] = Qwen3Tokenizer::TOKEN_TYPE_CONTROL;
+    data.eos_token_id = 262;
+
+    data.merges = {
+        "h e",
+        "l l",
+        "he ll",
+        "hell o",
+        base[' '] + std::string(" hello"),
+    };
+
+    Qwen3Tokenizer tokenizer;
+    std::string error;
+    assert(tokenizer.load(data, &error));
+    assert(tokenizer.ready());
+    assert(tokenizer.bos_token_id() == -1);
+    assert(tokenizer.eos_token_id() == 262);
+
+    const auto hello = tokenizer.encode("hello");
+    assert((hello == std::vector<int32_t>{259}));
+    const auto spaced = tokenizer.encode(" hello");
+    assert((spaced == std::vector<int32_t>{260}));
+
+    const std::string chinese = "你好";
+    const auto chinese_ids = tokenizer.encode(chinese);
+    assert(!chinese_ids.empty());
+    assert(tokenizer.decode(chinese_ids) == chinese);
+
+    const auto special = tokenizer.encode(
+        "<|im_start|>hello<|im_end|>");
+    assert((special == std::vector<int32_t>{261, 259, 262}));
+    assert(tokenizer.decode(special, true) == "hello");
+    assert(tokenizer.decode(special, false)
+        == "<|im_start|>hello<|im_end|>");
+
+    const auto with_eos = tokenizer.encode("hello", false, true);
+    assert((with_eos == std::vector<int32_t>{259, 262}));
+
+    const std::string prompt = tokenizer.format_chat_prompt(
+        "hi", "", false);
+    assert(prompt.find("<|im_start|>user\nhi<|im_end|>\n") == 0);
+    assert(prompt.find("<think>\n\n</think>\n\n") != std::string::npos);
+    return 0;
+}
+''',
+        encoding="utf-8",
+    )
+
+    compile_result = subprocess.run(
+        [
+            "g++",
+            "-std=c++17",
+            "-Wall",
+            "-Wextra",
+            "-Werror",
+            "-I",
+            str(TOKENIZER_HPP.parent),
+            str(harness),
+            str(TOKENIZER_CPP),
+            "-o",
+            str(binary),
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert compile_result.returncode == 0, compile_result.stderr
+
+    run_result = subprocess.run(
+        [str(binary)],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert run_result.returncode == 0, run_result.stderr

--- a/metainfer/tasks/gen_cpp_infer_framework/tests/test_qwen3_z200_kernel_contract.py
+++ b/metainfer/tasks/gen_cpp_infer_framework/tests/test_qwen3_z200_kernel_contract.py
@@ -13,12 +13,22 @@ KERNEL_SOURCE = (
 MODEL_CONTRACT = (
     Path(__file__).parents[1]
     / "notebooks"
-    / "03_qwen3_8b_cpp_contract.md"
+    / "03_qwen3_8b_contract.md"
 )
 OPERATOR_CONTRACT = (
     Path(__file__).parents[1]
     / "notebooks"
     / "04_qwen3_z200_operator_contract.md"
+)
+LOADER_CONTRACT = (
+    Path(__file__).parents[1]
+    / "notebooks"
+    / "05_qwen3_gguf_loader_notes.md"
+)
+RUNTIME_CONTRACT = (
+    Path(__file__).parents[1]
+    / "notebooks"
+    / "06_qwen3_runtime_notes.md"
 )
 
 
@@ -31,6 +41,7 @@ def test_q8_0_layout_and_required_entrypoints_are_present():
     assert "qwen3_z200_launch_cast_fp32_to_fp16" in source
     assert "qwen3_z200_launch_embedding_lookup_q8_0" in source
     assert "qwen3_z200_q8_linear_fp32" in source
+    assert "qwen3_z200_launch_greedy_sample" in source
 
 
 def test_q8_linear_uses_fp16_inputs_and_fp32_accumulation():
@@ -41,9 +52,9 @@ def test_q8_linear_uses_fp16_inputs_and_fp32_accumulation():
         'extern "C" hipError_t qwen3_z200_launch_embedding_lookup', 1
     )[0]
 
-    assert linear.count("HIP_R_16F") >= 2
-    assert "HIP_R_32F" in linear
-    assert "HIPBLAS_COMPUTE_32F" in linear
+    assert linear.count("HIPBLAS_R_16F") >= 2
+    assert linear.count("HIPBLAS_R_32F") >= 2
+    assert "hipblasGemmEx(" in linear
     assert "HIPBLAS_OP_T" in linear
     assert "HIPBLAS_OP_N" in linear
 
@@ -64,3 +75,21 @@ def test_single_gpu_contract_documents_the_runnable_q8_flow():
     assert "Fused QKV 必须 split/pack" in operator_contract
     assert "Fused gate-up 必须 pack 或使用 strided SwiGLU" in operator_contract
     assert "逐层 forward 和逐 token decode 中禁止 `hipMalloc/hipFree`" in operator_contract
+
+
+def test_greedy_sampler_runtime_contract_matches_current_kernel():
+    source = KERNEL_SOURCE.read_text(encoding="utf-8")
+    operator_contract = OPERATOR_CONTRACT.read_text(encoding="utf-8")
+    loader_contract = LOADER_CONTRACT.read_text(encoding="utf-8")
+    runtime_contract = RUNTIME_CONTRACT.read_text(encoding="utf-8")
+
+    assert "qwen3_z200_launch_greedy_sample" in source
+    assert "qwen3_z200_launch_greedy_sample" in operator_contract
+    assert "qwen3_z200_launch_greedy_sample" in loader_contract
+    assert "qwen3_z200_launch_greedy_sample" in runtime_contract
+    assert "sizeof(int32_t)" in runtime_contract
+    assert "runtime.stream()" in runtime_contract
+    assert "effective_stop_ids" in runtime_contract
+    assert "has_logits" in runtime_contract
+    assert "当前 kernel 文件没有 greedy sampler" not in loader_contract
+    assert "当前 `qwen3_z200_kernels.hip.cpp` **没有** greedy sampler" not in runtime_contract


### PR DESCRIPTION
- Generated C++ inference implementations can be evaluated at concurrency 1, 4, and 16.
- Document the C++ HTTP serving lifecycle and continuous batching scheduler/KV-slot contract.
- Restore the performance oracle concurrency ladder to 1/4/16 now that continuous batching is part of the generated framework contract.